### PR TITLE
Remove touchstone radio episodes page link from the top navbar

### DIFF
--- a/touchstone-radio-episodes.md
+++ b/touchstone-radio-episodes.md
@@ -7,7 +7,7 @@ layout: page
 guid: 'http://sastry.hcoop.net/srikanthwp/?page_id=60'
 fplayout:
     - default
-nav: true
+nav: false
 footer: true
 permalink: /touchstone-radio-episodes/
 ---


### PR DESCRIPTION
The top navbar is too long to load cleanly in mobile. Touchstone Radio Episodes ends up spilling the navbar over two lines and it starts overlapping with the main photo, which makes it looks ugly. So, this diff simply removes the link on the topnavbar. It is still accessible from the footer.