### PR TITLE
Garden notes: The merits of unit tests — Part 2 (Refactoring)

### DIFF
--- a/_garden/tests-as-refactoring-safety-net.md
+++ b/_garden/tests-as-refactoring-safety-net.md
@@ -1,0 +1,27 @@
+---
+title: "Tests as a Refactoring Safety Net"
+garden_type: note
+maturity: evergreen
+tags: [software-testing, unit-tests, refactoring, tech-debt]
+created: 2026-04-27
+related_posts:
+  - /the-merits-of-unit-tests-part-2/
+related_notes:
+  - tests-as-executable-documentation
+excerpt_text: >
+  Unit tests transform refactoring from a high-wire act into a routine operation.
+---
+
+Unit tests transform refactoring from a high-wire act into a routine operation. The rule of thumb: "As long as the unit tests pass, every iteration of your refactor is (most likely) correct."
+
+Software accrues tech debt through three predictable forces:
+
+1. **Environmental assumptions change** — the unique-username assumption breaks when shared family accounts arrive.
+2. **Undisciplined changes accumulate** — junior engineers or vacation-time patches introduce expedient hacks that violate the original design.
+3. **Software gets co-opted** — a geo-spatial indexing service built for cities gets shoehorned into indexing stores in malls.
+
+Eventually the debt compounds enough to impede forward progress, and refactoring becomes necessary. The core challenge: you must rewrite internals while preserving all existing behavior. Any deviation triggers failures elsewhere in the system.
+
+With a diligent, up-to-date test suite with sufficient path coverage, refactoring becomes tractable. Without one, you're reduced to gingerly making incremental changes and validating in production — a process that stretches days or weeks and multiplies risk.
+
+The tests don't just verify correctness during refactoring; they *define* what "correct" means. They're the behavioral contract that survives the rewrite.

--- a/_posts/2017-11-12-the-merits-of-unit-tests-part-2.md
+++ b/_posts/2017-11-12-the-merits-of-unit-tests-part-2.md
@@ -92,7 +92,7 @@ redesign your software to reflect the new world it is in.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>In my experience, one of the most delicate things about refactoring 
+<p>In my experience, one of the most delicate things about <a href="/garden/tests-as-refactoring-safety-net/">refactoring</a> 
 such code is that you often have to rewrite the software but keep all of
  its existing behavior intact. Any failure to do so will start 
 triggering failures in the system-at-large. Having good unit tests can 


### PR DESCRIPTION
Atomic garden notes extracted from 'The merits of unit tests — Part 2'.

Notes created:
- `tests-as-refactoring-safety-net` — Unit tests as the behavioral contract that survives rewrites, transforming refactoring from high-wire act to routine operation.