### PR TITLE
Garden notes: Unit tests FTW! — Part 4 (Debugging)

### DIFF
--- a/_garden/tests-prune-debugging-search-space.md
+++ b/_garden/tests-prune-debugging-search-space.md
@@ -1,0 +1,22 @@
+---
+title: "Tests Prune the Debugging Search Space"
+garden_type: note
+maturity: evergreen
+tags: [software-testing, unit-tests, debugging]
+created: 2026-04-27
+related_posts:
+  - /unit-tests-ftw-part-4/
+related_notes:
+  - testability-drives-design
+  - tests-as-refactoring-safety-net
+excerpt_text: >
+  When a production issue arises and you narrow it to your code, unit tests perform a crucial elimination function: every code path covered by a passing test is a code path you can rule out as the offender.
+---
+
+When a production issue arises and you narrow it to your code, unit tests perform a crucial elimination function: every code path covered by a passing test is a code path you can rule out as the offender. This pruning makes debugging tractable where it would otherwise be combinatorial.
+
+The number of code paths in a class often grows exponentially with code size. A good test suite covers sufficiently many of these paths that the remaining search space — the set of plausible root causes — becomes manageable. Without tests, you're searching a haystack. With tests, you've already removed most of the hay.
+
+This is more than convenience. Once the search space is pruned, you can form a strong hypothesis about the root cause (e.g., "this is probably a race condition in the `allResponses()` function"). From there, reproducing and verifying the bug is straightforward — not necessarily easy, but directed rather than speculative.
+
+The implication: unit tests have value even for code you're confident is correct *today*, because they pre-invest in debugging speed for the inevitable production issue *tomorrow*.

--- a/_posts/2017-11-28-unit-tests-ftw-part-4.md
+++ b/_posts/2017-11-28-unit-tests-ftw-part-4.md
@@ -41,9 +41,9 @@ tests are often a lot more lines of code than the actual production code
 <!-- wp:paragraph -->
 <p>If your unit tests cover sufficiently many code paths (which any good
  unit test suite should do), then when an issue arises in production, 
-and you narrow it down to your code, then you know that the offending 
-code path could not have been the several code paths that your unit 
-tests already covered. This pruning makes your debugging a lot simpler 
+and you narrow it down to your code, then you know that the <a href="/garden/tests-prune-debugging-search-space/">offending
+ code path could not have been the several code paths that your unit 
+tests already covered</a>. This pruning makes your debugging a lot simpler 
 than before.</p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
Atomic garden notes extracted from 'Unit tests FTW! — Part 4'.

Notes created:
- `tests-prune-debugging-search-space` — Unit tests eliminate code paths from suspicion during production debugging, making root cause analysis tractable.