### PR TITLE
Garden notes: Scripts and their undo

### DIFF
--- a/_garden/every-mutation-needs-an-undo.md
+++ b/_garden/every-mutation-needs-an-undo.md
@@ -1,0 +1,20 @@
+---
+title: "Every Mutation Needs an Undo"
+garden_type: note
+maturity: evergreen
+tags: [operations, scripts, software-engineering, safety]
+created: 2026-04-27
+related_posts:
+  - /scripts-and-their-undo/
+related_notes: []
+excerpt_text: >
+  When writing scripts that mutate the state of the world — deployments, replica changes, configuration updates — always build an undo mechanism alongside the forward operation.
+---
+
+When writing scripts that mutate the state of the world — deployments, replica changes, configuration updates — always build an undo mechanism alongside the forward operation.
+
+The pressure to skip this is real: the forward path is the goal, the undo feels like defensive overhead. But when you need it (and you will), you need it *immediately* — under time pressure, during someone else's incident, with adrenaline compromising your judgment. A hastily improvised undo under those conditions is more likely to make things worse than better.
+
+The practical rule: every mutation script should log the exact command(s) needed to reverse its effects. The undo doesn't need to be a separate script — it can be as simple as printing the inverse commands to stdout as the forward operations execute. What matters is that the reversal path exists and is tested *before* you need it.
+
+This is a specific instance of a broader principle: any operation that changes system state should be designed for reversibility by default. The cost of building the undo is paid once; the cost of not having it is paid repeatedly and unpredictably.

--- a/_posts/2019-01-11-scripts-and-their-undo.md
+++ b/_posts/2019-01-11-scripts-and-their-undo.md
@@ -21,7 +21,7 @@ image: /assets/images/2019/01/bash-logo-672x372.png
 <!-- /wp:cover -->
 
 <!-- wp:paragraph -->
-<p>Some time ago, I had to carry out a long sequence of manual changes in the deployment of my ‘cloud’ service, and so like a good software engineer, I automated large chunks of these changes with shell scripts. Here I learned the importance of building and ‘undo’ in all your shell scripts that mutate the state of world.</p>
+<p>Some time ago, I had to carry out a long sequence of manual changes in the deployment of my ‘cloud’ service, and so like a good software engineer, I automated large chunks of these changes with shell scripts. Here I learned the importance of building an <a href="/garden/every-mutation-needs-an-undo/">‘undo’ in all your shell scripts</a> that mutate the state of world.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:more {"customText":"Read more"} -->


### PR DESCRIPTION
Atomic garden notes extracted from 'Scripts and their undo'.

Notes created:
- `every-mutation-needs-an-undo` — Every script that mutates state should log the exact commands needed to reverse its effects.