### PR TITLE
Remove text decoration from garden cards and links

### DIFF
--- a/assets/css/garden.css
+++ b/assets/css/garden.css
@@ -94,3 +94,17 @@ a[data-garden-link]:hover {
 .dark a[data-garden-link]:hover {
   text-decoration-color: #22c55e;
 }
+
+/* Suppress green underline on garden cards (home page, garden index) */
+.garden-card[data-garden-link],
+.garden-card a[data-garden-link],
+#garden a[data-garden-link] {
+  text-decoration: none;
+}
+
+.garden-card[data-garden-link]:hover,
+.garden-card a[data-garden-link]:hover,
+#garden a[data-garden-link]:hover {
+  text-decoration: none;
+}
+


### PR DESCRIPTION
Suppress green underline on garden cards and links.