### PR TITLE
Garden notes: Responding to concerns as a people manager

### DIFF
--- a/_garden/concern-response-framework.md
+++ b/_garden/concern-response-framework.md
@@ -1,0 +1,28 @@
+---
+title: "Concern Response Framework for Managers"
+garden_type: note
+maturity: evergreen
+tags: [people-management, leadership, communication]
+created: 2026-04-27
+related_posts:
+  - /responding-to-concerns-as-a-people-manager/
+related_notes: []
+excerpt_text: >
+  A seven-step framework for how managers should respond when a team member raises a concern.
+---
+
+A seven-step framework for how managers should respond when a team member raises a concern. The framework focuses on *understanding the issue* rather than *resolving* it — resolution is situation-specific, but the approach to understanding should be consistent.
+
+1. **Listen** — Really listen. Take what they say at face value. Resist the impulse to connect dots or form hypotheses. Repeat back in your own words until they confirm you've captured it.
+
+2. **Empathize** — Even if you disagree, understand where they're coming from. The person must feel validated, not diminished. Failing here guarantees they'll stop sharing and eventually leave.
+
+3. **Don't take notes** — Notes impede listening, undermine empathy, and create a chilling effect on candor. The conversation came with an implicit expectation of confidentiality; putting things "on the record" makes the speaker guarded.
+
+4. **Descend into the particular** — Stay focused on the specific issue. Do not generalize or abstract. Solve the concrete problem first; address systemic patterns separately.
+
+5. **Check with others** — Before attempting resolution, determine if the issue is isolated or widespread. Do this urgently — delay signals indifference.
+
+6. **Socialize if common** — If the issue affects multiple people, make it visible. The organization must demonstrate willingness to engage in difficult conversations.
+
+7. **Never become an apologist** — Do not justify the status quo. Explaining away someone's concern is victim-blaming in professional clothing. Whatever resolution follows will land better if you don't.

--- a/_posts/2019-12-31-responding-to-concerns-as-a-people-manager.md
+++ b/_posts/2019-12-31-responding-to-concerns-as-a-people-manager.md
@@ -22,7 +22,7 @@ tags:
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p>Note that this doesn’t talk about the resolution for the issue. That is very specific to the issue at hand. What I have is more of an approach to understanding the issue in a manner that is respectful of the stakeholders. With that disclaimer, let’s unpack each of those bullet points.</p>
+<p>Note that this doesn’t talk about the resolution for the issue. That is very specific to the issue at hand. What I have is more of an <a href="/garden/concern-response-framework/">approach to understanding the issue</a> in a manner that is respectful of the stakeholders. With that disclaimer, let’s unpack each of those bullet points.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:more -->


### PR DESCRIPTION
Notes created:
- `concern-response-framework` — Seven-step framework for handling team concerns: listen, empathize, don't take notes, descend into the particular, check with others, socialize if common, never apologize for status quo.