### PR TITLE
Garden notes: Donts of processes for upward communication

### DIFF
--- a/_garden/upward-communication-anti-patterns.md
+++ b/_garden/upward-communication-anti-patterns.md
@@ -1,0 +1,25 @@
+---
+title: "Upward Communication Anti-Patterns"
+garden_type: note
+maturity: evergreen
+tags: [people-management, leadership, communication, organizational-design]
+created: 2026-04-27
+related_posts:
+  - /donts-of-processes-for-upward-communication/
+related_notes:
+  - concern-response-framework
+excerpt_text: >
+  Upward communication is critical to organizational health but notoriously difficult due to inherent power differentials in hierarchies.
+---
+
+Upward communication is critical to organizational health but notoriously difficult due to inherent power differentials in hierarchies. Most failures share four anti-patterns:
+
+1. **Format over framework** — Organizations obsess over the template (weekly email, status doc, particular form) instead of establishing *why* the communication exists and *what* should flow through it. The format becomes the goal; the substance gets lost.
+
+2. **Asymmetric commitment** — Leadership asks for upward communication but doesn't reciprocate with downward communication of equal substance and frequency. Engineers notice the one-way street and disengage.
+
+3. **No response to content** — Information flows up and disappears into a void. When leadership never acknowledges, responds to, or acts on what they receive, contributors learn that the communication is performative and stop putting real signal into it.
+
+4. **No engineer buy-in** — The process was designed by and for management without consulting the people who must actually do the communicating. Without buy-in from contributors, the process becomes compliance theater.
+
+The common thread: every failure stems from ignoring the power differential that makes upward communication fragile in the first place. Successful upward communication actively mitigates this differential rather than pretending it doesn't exist.

--- a/_posts/2020-02-11-donts-of-processes-for-upward-communication.md
+++ b/_posts/2020-02-11-donts-of-processes-for-upward-communication.md
@@ -18,7 +18,7 @@ tags:
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
-<p>Upward communication critical to organizational well-being and effectiveness. It is also notoriously difficult to get right due to the inherent power/authority differential involved in the hierarchy of any organization. Almost every place that I have seen upward communication done right focuses on mitigating this differential. Unfortunately, many organizations seem to be completely oblivious of how the existing power differential within a hierarchy can jeopardize upward communication. </p>
+<p>Upward communication critical to organizational well-being and effectiveness. It is also notoriously difficult to get right due to the inherent power/authority differential involved in the hierarchy of any organization. Almost every place that I have seen upward communication done right focuses on mitigating this differential. Unfortunately, many organizations seem to be completely oblivious of how the existing power differential within a hierarchy can <a href="/garden/upward-communication-anti-patterns/">jeopardize upward communication</a>. </p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
Notes created:
- `upward-communication-anti-patterns` — Four anti-patterns that kill upward communication: format over framework, asymmetric commitment, no response to content, no engineer buy-in.