### PR TITLE
Garden notes: The Law of Demeter and unit tests

### DIFF
--- a/_garden/law-of-demeter-and-testing.md
+++ b/_garden/law-of-demeter-and-testing.md
@@ -1,0 +1,22 @@
+---
+title: "Law of Demeter and Testing"
+garden_type: note
+maturity: evergreen
+tags: [software-testing, unit-tests, law-of-demeter, software-design, coupling]
+created: 2026-04-27
+related_posts:
+  - /law-of-demeter-and-unit-tests/
+related_notes:
+  - minimize-public-surface-for-testability
+  - testability-drives-design
+excerpt_text: >
+  The Law of Demeter ("only talk to your immediate friends") takes two forms relevant to testability:
+---
+
+The Law of Demeter ("only talk to your immediate friends") takes two forms relevant to testability:
+
+**Object chains:** Code like `a.getB().getC().doThing()` forces tests to set up the entire chain of collaborators as mocks. Each link requires another mock, and changing any link cascades test failures. The fix: push behavior toward the object that owns the data — encapsulate operations within the immediate dependency.
+
+**Fat parameters:** Passing a large data object (e.g., an entire `Customer`) when the function only needs two fields (name, email) creates test noise. Every test must construct a complete object with irrelevant fields, making it unclear which fields matter. The fix: accept only the data the function needs.
+
+Both forms create the same testing problem: tests that know too much about collaborator structure, making them brittle and hard to read. Demeter violations in production code become mock chains and bloated test fixtures in test code — the test is telling you the design needs work.

--- a/_posts/2022-07-22-the-law-of-demeter-and-unit-tests.md
+++ b/_posts/2022-07-22-the-law-of-demeter-and-unit-tests.md
@@ -12,7 +12,7 @@ permalink: /law-of-demeter-and-unit-tests/
 image: /assets/images/demeter-sketch-bw.jpg
 ...
 <!-- ![](/assets/images/demeter-sketch-bw.jpg) -->
-The [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) essentially says that each unit should only talk to its 'immediate friends' or 'immediate dependencies', and in spirit, it is pointing to the principle that each unit only have the information it needs to meet its purpose. In that spirit, the Law of Demeter takes two forms that are relevant to making your code more testable: (1) object chains, and (2) fat parameters.
+The [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) essentially says that each unit should only talk to its 'immediate friends' or 'immediate dependencies', and in spirit, it is pointing to the principle that each unit only have the information it needs to meet its purpose. In that spirit, the Law of Demeter takes two forms that are relevant to <a href="/garden/law-of-demeter-and-testing/">making your code more testable</a>: (1) object chains, and (2) fat parameters.
 
 ## Object Chains
 


### PR DESCRIPTION
Notes: law-of-demeter-and-testing — Object chains and fat parameters undermine testability.