### PR TITLE
Garden notes: Let sleeping engineers lie

### DIFF
--- a/_garden/align-alerts-to-sev-criteria.md
+++ b/_garden/align-alerts-to-sev-criteria.md
@@ -1,0 +1,18 @@
+---
+title: "Align Alerts to SEV Criteria"
+garden_type: note
+maturity: evergreen
+tags: [operations, alerting, monitoring, SLOs, on-call]
+created: 2026-04-27
+related_posts:
+  - /sync-your-alerts-to-your-sev-criteria/
+related_notes: []
+excerpt_text: >
+  Alerts should fire at or near the threshold where an SLO breach (and therefore a SEV) would occur — not well before.
+---
+
+Alerts should fire at or near the threshold where an SLO breach (and therefore a SEV) would occur — not well before. Premature alerts create noise, erode trust in the alerting system, and burn out on-call engineers with false urgency.
+
+When alerts fire for conditions that don't correspond to real severity criteria, the on-call workflow degrades: engineers learn to distrust pages, investigate phantom issues, and escalate reflexively rather than with judgment.
+
+The rule: if an alert wakes someone at 4 AM, there should be a clear SEV, an SLO breach, or measurable user impact. If none of those exist, the alert threshold needs recalibration.

--- a/_posts/2025-06-07-let-sleeping-engineers-lie-why-your-alerts-should-match-your-sevs.md
+++ b/_posts/2025-06-07-let-sleeping-engineers-lie-why-your-alerts-should-match-your-sevs.md
@@ -43,4 +43,4 @@ Here’s what actually happened:
 We could’ve all just slept through it and looked at it with fresh eyes in the morning. Instead, two engineers got pulled into zombie mode to stare at graphs that improved all by themselves. It was like debugging a ghost.
 
 ### Moral of the story:
-If your alert is going to wake someone up at 4 AM, it better be for something that *actually* matters. If there's no SEV, no SLO breach, and no clear user impact — maybe let sleeping engineers lie.
+If your <a href="/garden/align-alerts-to-sev-criteria/">alert is going to wake someone up at 4 AM</a>, it better be for something that *actually* matters. If there's no SEV, no SLO breach, and no clear user impact — maybe let sleeping engineers lie.


### PR DESCRIPTION
Notes: align-alerts-to-sev-criteria — Alerts should fire at SLO-breach thresholds, not before.