### PR TITLE
Garden notes: Backward compatibility rescues leaky abstractions

### DIFF
--- a/_garden/backward-compatibility-for-leaky-abstractions.md
+++ b/_garden/backward-compatibility-for-leaky-abstractions.md
@@ -1,0 +1,22 @@
+---
+title: "Backward Compatibility for Leaky Abstractions"
+garden_type: note
+maturity: evergreen
+tags: [software-engineering, backward-compatibility, leaky-abstractions, defensive-programming]
+created: 2026-04-27
+related_posts:
+  - /backward-compatibility-where-you-dont-expect/
+related_notes: []
+excerpt_text: >
+  When a framework leaks implementation details — like serializing function arguments at schedule time but loading function code from HEAD at execution time — changing a function signature breaks the assumption that old code calls old signatures and new code calls new ones.
+---
+
+When a framework leaks implementation details — like serializing function arguments at schedule time but loading function code from HEAD at execution time — changing a function signature breaks the assumption that old code calls old signatures and new code calls new ones.
+
+The defensive fix is a three-step backward-compatible migration:
+
+1. **Add `**kwargs` and defaults:** Accept unknown parameters without crashing. Log warnings for unrecognized args. Make all params optional with sensible defaults.
+2. **Change the signature:** Old serialized payloads pass old params via `**kwargs`; new payloads pass new params directly. Branch logic based on which params are present.
+3. **Delete old logic:** Once all old payloads have drained, remove the backward-compat branch.
+
+This pattern — familiar from protobuf's all-fields-optional philosophy — works whenever callers and callees can evolve at different speeds, whether due to leaky abstractions, rolling deploys, or serialized state.

--- a/_posts/2025-07-02-when-backward-compatibility-can-rescue-leaky-abstraction.md
+++ b/_posts/2025-07-02-when-backward-compatibility-can-rescue-leaky-abstraction.md
@@ -19,7 +19,7 @@ excerpt: >
 I ran into one of those delightful bugs that only show up in dynamic task generation of your data pipelines — the kind that teach you how a leaky abstraction in your pipeline platform can have you scratching your head in confusion.
 
 The short version:
-I made a simple function signature change, assuming only future runs would care. Instead, my pipeline broke days later when an old task serialized under the previous signature collided with the new code. The fix? Classic backward compatibility tricks that saved me from babysitting all existing task runs when making changes in the future.
+I made a simple function signature change, assuming only future runs would care. Instead, my pipeline broke days later when an old task serialized under the previous signature collided with the new code. The fix? Classic <a href="/garden/backward-compatibility-for-leaky-abstractions/">backward compatibility tricks</a> that saved me from babysitting all existing task runs when making changes in the future.
 
 Here’s the story — and how to avoid learning this lesson the hard way.
 


### PR DESCRIPTION
Notes: backward-compatibility-for-leaky-abstractions — kwargs + defaults as defense against serialized-state mismatches.