### PR TITLE
Fix: accept garden maturity values in pkm-to-garden.sh

### DIFF
--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -114,11 +114,10 @@ derive_maturity() {
         return
     fi
     case "$status" in
-        connected|stable) echo "evergreen" ;;
-        developing)       echo "budding" ;;
-        draft)            echo "budding" ;;
-        raw|"")           echo "seedling" ;;
-        *)                echo "seedling" ;;
+        evergreen|connected|stable) echo "evergreen" ;;
+        budding|developing|draft)   echo "budding" ;;
+        seedling|raw|"")            echo "seedling" ;;
+        *)                          echo "seedling" ;;
     esac
 }
 


### PR DESCRIPTION
The `derive_maturity` function now accepts `evergreen`, `budding`, and `seedling` directly as status values, in addition to the PKM-native mappings (`connected`, `stable`, `developing`, `draft`, `raw`).