### PR TITLE
Fix: home page sections too spaced out on large monitors

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@ layout: default
 
 <section
   id="main"
-  class="flex flex-col md:flex-row items-center justify-center py-16 md:h-screen border-b-2 dark:border-0"
+  class="flex flex-col md:flex-row items-center justify-center py-16 md:min-h-[60vh] md:max-h-[75vh] border-b-2 dark:border-0"
 >
   <div class="md:mx-2" data-motion="fadeInLeft">
     <img
@@ -30,7 +30,7 @@ layout: default
 {% if site.posts.size > 0 %}
 <section
   id="blog"
-  class="md:inout container mx-auto flex flex-col items-center justify-center min-h-screen"
+  class="md:inout container mx-auto flex flex-col items-center justify-center"
 >
   <div class="py-16 w-full">
     <h2 class="text-3xl font-bold text-center md:text-left" data-motion="fadeInUp">
@@ -105,7 +105,7 @@ layout: default
 {% if site.projects.size > 0 %}
 <section
   id="projects"
-  class="md:inout container mx-auto flex flex-col items-center justify-center min-h-screen"
+  class="md:inout container mx-auto flex flex-col items-center justify-center"
 >
   <div class="py-16 w-full">
     <h2 class="text-3xl font-bold text-center md:text-left" data-motion="fadeInUp">
@@ -135,7 +135,7 @@ layout: default
 {% if trimmed_content != "" %}
   <section
     id="content"
-    class="inout container mx-auto flex flex-col items-center justify-center min-h-screen"
+    class="inout container mx-auto flex flex-col items-center justify-center"
   >
     <article class="prose prose-lg dark:prose-invert prose-h1:text-5xl prose-h2:text-3xl mx-auto py-16" data-motion="fadeInUp">{{content}}</article>
   </section>


### PR DESCRIPTION
On large monitors, the full-viewport hero pushed blog and garden sections far below the fold with no visual hint they existed.

**Changes:**
- Hero (about me): `md:h-screen` → `md:min-h-[60vh] md:max-h-[75vh]` — substantial but capped
- Blog, projects, content sections: removed `min-h-screen` — size to content with existing padding

The page now feels denser and more browsable. The dot nav still works for section jumping.