### PR TITLE
Fix: garden notes invisible on mobile

### DIFF
--- a/_layouts/garden-index.html
+++ b/_layouts/garden-index.html
@@ -26,7 +26,7 @@ layout: default
     {% endfor %}
   {% endfor %}
 
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" data-motion="fadeInUp">
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     {% for note in all_notes %}
       <a href="{{ note.url | relative_url }}" class="garden-card no-underline block p-4 rounded-lg border border-neutral-200 dark:border-neutral-800 hover:border-neutral-400 dark:hover:border-neutral-600 transition">
         <div class="flex items-start gap-2 mb-2">


### PR DESCRIPTION
## Problem
The garden index page is blank on mobile. Notes exist in the DOM but are invisible.

## Root Cause
The theme's animation system sets `opacity: 0` on elements with `data-motion` and uses an `IntersectionObserver` with `threshold: 0.2` to trigger the fade-in. The grid container wrapping all 68 notes has `data-motion="fadeInUp"`.

On mobile (single-column layout), the grid is ~10,000px tall. The observer requires 20% (2,000px) to be visible simultaneously, but the phone viewport is only ~844px. The threshold can never be met, so the animation never fires, and the grid stays at `opacity: 0` permanently.

This was always latent but got worse as more notes were added.

## Fix
Remove `data-motion` from the grid container. The header and legend still animate fine (they're small elements that easily meet the 20% threshold).