### PR TITLE
Fix Giscus initial theme race condition on page load

### DIFF
--- a/_includes/comment_system.html
+++ b/_includes/comment_system.html
@@ -11,11 +11,17 @@
   <h2 class="text-xl font-bold mb-6 text-neutral-900 dark:text-neutral-100">Comments</h2>
   <script>
     (function() {
+      // Read the same source of truth as the blog's theme switcher:
+      // localStorage 'theme' key, falling back to OS preference.
+      // This avoids a race with DOMContentLoaded where <html class="dark">
+      // is the SSR default but hasn't been corrected yet for light-mode users.
       function isDark() {
-        return document.documentElement.classList.contains('dark');
+        var saved = localStorage.getItem('theme');
+        if (saved) return saved === 'dark';
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
       }
 
-      // Use Giscus built-in themes — no custom CSS needed
+      // Use Giscus built-in themes
       var s = document.createElement('script');
       s.src = 'https://giscus.app/client.js';
       s.setAttribute('data-repo', 'srikanthsastry/srikanthsastry.github.io');


### PR DESCRIPTION
The SSR HTML always ships `<html class="dark">`, and the blog's theme JS corrects it on `DOMContentLoaded`. The Giscus IIFE ran before that correction, so `isDark()` always returned `true` on first load — making the comment widget render in dark mode even for light-mode users.

**Fix:** Read `localStorage('theme')` directly (the same source of truth the blog's theme switcher uses), falling back to the OS `prefers-color-scheme` media query. This matches the blog's own theme logic without waiting for `DOMContentLoaded`.

The `MutationObserver` still handles live toggle changes as before.