### PR TITLE
Convert 6 photo-heavy posts from HTML to markdown

### DIFF
--- a/_posts/2015-08-30-tsarevets-a-photo-essay.md
+++ b/_posts/2015-08-30-tsarevets-a-photo-essay.md
@@ -4,10 +4,7 @@ title: 'Tsarevets: a photo essay'
 date: '2015-08-30T09:25:07-04:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'http://srikanth.sastry.name/?p=139'
 permalink: /tsarevets-a-photo-essay/
-fplayout:
-    - fullwidth
 categories:
     - Personal
 format: image
@@ -17,142 +14,82 @@ tags:
 image: /assets/images/2015/08/IMG_20150829_110825-e1440950848706.jpg
 ---
 
-<!-- wp:paragraph {"className":"firstHeading"} -->
-<p class="firstHeading"><a href="https://en.wikipedia.org/wiki/Tsarevets_(fortress)">Tsarevets fortress</a> was a medieval stronghold of the erstwhile <a href="https://en.wikipedia.org/wiki/Second_Bulgarian_Empire">Second Bulgarian Empire</a> located near the city of&nbsp;<a href="https://en.wikipedia.org/wiki/Veliko_Tarnovo">Veliko Tarnovo</a>&nbsp;(which was also the capital city of that empire).&nbsp;While the fortress is in ruins, the recent reconstructions and restorations make it worth visiting.</p>
-<!-- /wp:paragraph -->
+[Tsarevets fortress](https://en.wikipedia.org/wiki/Tsarevets_(fortress)) was a medieval stronghold of the erstwhile [Second Bulgarian Empire](https://en.wikipedia.org/wiki/Second_Bulgarian_Empire) located near the city of [Veliko Tarnovo](https://en.wikipedia.org/wiki/Veliko_Tarnovo) (which was also the capital city of that empire). While the fortress is in ruins, the recent reconstructions and restorations make it worth visiting.
 
-<!-- wp:image {"id":141,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_110825-e1440950848706.jpg"><img src="/assets/images/2015/08/IMG_20150829_110825-e1440950848706.jpg" alt="View of the fortress from the city." class="wp-image-141"/></a><figcaption>View of the fortress from the city.</figcaption></figure>
-<!-- /wp:image -->
+![View of the fortress from the city.](/assets/images/2015/08/IMG_20150829_110825-e1440950848706.jpg)
 
-<!-- wp:paragraph -->
-<p>The fortress itself is situated on top of a hill of the same name. The stronghold consisted of two forts, one on each hill. You can see the ruins of the second fort on the hill in the left hand side of the photograph above. The second fort is not reconstructed well enough to attract tourists.</p>
-<!-- /wp:paragraph -->
+The fortress itself is situated on top of a hill of the same name. The stronghold consisted of two forts, one on each hill. You can see the ruins of the second fort on the hill in the left hand side of the photograph above. The second fort is not reconstructed well enough to attract tourists.
 
-<!-- wp:paragraph -->
-<p>Let's step inside.</p>
-<!-- /wp:paragraph -->
+Let's step inside.
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+## Entry
 
-<!-- wp:heading -->
-<h2>Entry</h2>
-<!-- /wp:heading -->
+![You enter the fort complex from the city on a ridge](/assets/images/2015/08/IMG_20150829_111416.jpg)
 
-<!-- wp:image {"id":142,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_111416.jpg"><img src="/assets/images/2015/08/IMG_20150829_111416-1024x760.jpg" alt="You enter the fort complex from the city on a ridge" class="wp-image-142"/></a><figcaption>You enter the fort complex from the city on a ridge</figcaption></figure>
-<!-- /wp:image -->
+The ridge separating the fortress and the city is more apparent when viewing the city from inside the fort.
 
-<!-- wp:paragraph -->
-<p>The ridge separating the fortress and the city is more apparent when viewing the city from inside the fort.</p>
-<!-- /wp:paragraph -->
+![Notice the ridge that connects Veliko Tarnovo city to the fortress.](/assets/images/2015/08/IMG_20150829_112018.jpg)
 
-<!-- wp:image {"id":143,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_112018.jpg"><img src="/assets/images/2015/08/IMG_20150829_112018-1024x760.jpg" alt="Notice the ridge that connects Veliko Tarnovo city to the fortress" class="wp-image-143"/></a><figcaption>Notice the ridge that connects Veliko Tarnovo city to the fortress.</figcaption></figure>
-<!-- /wp:image -->
+From the Tsarevets fortress, you can see parts of the reconstructions of the second fortress (Trapezitsa) on the neighboring hill.
 
-<!-- wp:paragraph -->
-<p>From the Tsarevets fortress, you can see parts of the reconstructions of the second fortress (Trapezitsa) on the neighboring hill.</p>
-<!-- /wp:paragraph -->
+![Reconstructed watch tower on Trapezitsa as seen from Tsarevets.](/assets/images/2015/08/IMG_20150829_112024.jpg)
 
-<!-- wp:image {"id":145,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_112024.jpg"><img src="/assets/images/2015/08/IMG_20150829_112024-e1440951061942.jpg" alt="Reconstructed watch tower of Trapezitsa as seen from Tsarevets." class="wp-image-145"/></a><figcaption>Reconstructed watch tower on Trapezitsa as seen from Tsarevets.</figcaption></figure>
-<!-- /wp:image -->
+## Ruins
 
-<!-- wp:heading -->
-<h2>Ruins</h2>
-<!-- /wp:heading -->
+The ruins in the fortress have been well preserved, for the most part.
 
-<!-- wp:paragraph -->
-<p>The ruins in the fortress have been well preserved, for the most part.</p>
-<!-- /wp:paragraph -->
+![Well preserved ruins.](/assets/images/2015/08/IMG_20150829_122506.jpg)
 
-<!-- wp:image {"id":146,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_122506.jpg"><img src="/assets/images/2015/08/IMG_20150829_122506-e1440951090373.jpg" alt="Well preserved ruins" class="wp-image-146"/></a><figcaption>Well preserved ruins.</figcaption></figure>
-<!-- /wp:image -->
+![Most of these ruins were civilian buildings. After all this was part of the capital city.](/assets/images/2015/08/IMG_20150829_123317-e1440951114883.jpg)
 
-<!-- wp:image {"id":147,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_123317-e1440951114883.jpg"><img src="/assets/images/2015/08/IMG_20150829_123317-e1440951114883.jpg" alt="Most of these ruins were civilian buildings. After all this was the capital city." class="wp-image-147"/></a><figcaption>Most of these ruins were civilian buildings. After all this was part of the capital city.</figcaption></figure>
-<!-- /wp:image -->
+## Reconstructions
 
-<!-- wp:heading -->
-<h2>Reconstructions</h2>
-<!-- /wp:heading -->
+Also, there are a lot of reconstructions, especially along the outer wall of the fortress.
 
-<!-- wp:paragraph -->
-<p>Also, there are a lot of reconstructions, especially along the outer wall of the fortress.</p>
-<!-- /wp:paragraph -->
+![This is a reconstructed small chamber attached to outer wall.](/assets/images/2015/08/IMG_20150829_120235-e1440951134858.jpg)
 
-<!-- wp:image {"id":148,"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><a href="/assets/images/2015/08/IMG_20150829_120235-e1440951134858.jpg"><img src="/assets/images/2015/08/IMG_20150829_120235-e1440951134858.jpg" alt="This is a reconstructed small chamber attached to outer wall." class="wp-image-148"/></a><figcaption>This is a reconstructed small chamber attached to outer wall.</figcaption></figure></div>
-<!-- /wp:image -->
+![Only the outer wall is reconstructed. The inner buildings' ruins remain as just plans on the ground.](/assets/images/2015/08/IMG_20150829_122451-e1440951158106.jpg)
 
-<!-- wp:image {"id":149,"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><a href="/assets/images/2015/08/IMG_20150829_122451-e1440951158106.jpg"><img src="/assets/images/2015/08/IMG_20150829_122451-e1440951158106.jpg" alt="Only the outer wall is reconstructed. The inner buildings' ruins remain as just plans on the ground." class="wp-image-149"/></a><figcaption>Only the outer wall is reconstructed. The inner buildings' ruins remain as just plans on the ground.</figcaption></figure></div>
-<!-- /wp:image -->
+![Part of the outer wall is reconstructed. Notice the reconstructed turret.](/assets/images/2015/08/IMG_20150829_122457-e1440951268695.jpg)
 
-<!-- wp:image {"id":150,"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><a href="/assets/images/2015/08/IMG_20150829_122457-e1440951268695.jpg"><img src="/assets/images/2015/08/IMG_20150829_122457-e1440951268695.jpg" alt="Part of the outer wall is reconstructed. Notice the reconstructed turret." class="wp-image-150"/></a><figcaption>Part of the outer wall is reconstructed. Notice the reconstructed turret.</figcaption></figure></div>
-<!-- /wp:image -->
+![The outer wall reconstruction is impressive. Notice the reconstructed watch tower and a reconstructed turret.](/assets/images/2015/08/IMG_20150829_123355.jpg)
 
-<!-- wp:image {"id":151,"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><a href="/assets/images/2015/08/IMG_20150829_123355.jpg"><img src="/assets/images/2015/08/IMG_20150829_123355-e1440951294652.jpg" alt="The outer wall reconstruction is impressive. Notice the reconstructed watch tower" class="wp-image-151"/></a><figcaption>The outer wall reconstruction is impressive. Notice the reconstructed watch tower and a reconstructed turret.</figcaption></figure></div>
-<!-- /wp:image -->
+## Church
 
-<!-- wp:heading -->
-<h2>Church</h2>
-<!-- /wp:heading -->
+At the top of the fortress is a reconstruction of the church that once stood there. The church is called the [Patriarchal Cathedral of the Holy Ascension of God](https://en.wikipedia.org/wiki/Patriarchal_Cathedral_of_the_Holy_Ascension_of_God). It was built in the place of an early Christian church.
 
-<!-- wp:paragraph -->
-<p>At the top of the fortress is a reconstruction of the church that once stood there. The church is called the <a href="https://en.wikipedia.org/wiki/Patriarchal_Cathedral_of_the_Holy_Ascension_of_God">Patriarchal Cathedral of the Holy Ascension of God</a>. It was built in the place of an early Christian church.</p>
-<!-- /wp:paragraph -->
+![The reconstructed church. While the outside looks simple, the inside is simply beautiful.](/assets/images/2015/08/IMG_20150829_115024-e1440951320333.jpg)
 
-<!-- wp:image {"id":152,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_115024-e1440951320333.jpg"><img src="/assets/images/2015/08/IMG_20150829_115024-e1440951320333.jpg" alt="The reconstructed church. While the outside looks simple, the inside is simply beautiful." class="wp-image-152"/></a><figcaption>The reconstructed church. <br>While the outside looks simple, the inside is simply beautiful.</figcaption></figure>
-<!-- /wp:image -->
+When you step inside the church, you realize that this is really not a reconstruction, but in fact, a complete reimagining of an early christian church with a modernist abstract expression.
 
-<!-- wp:paragraph -->
-<p>When you step inside the church, you realize that this is really not a reconstruction, but in fact, a complete reimagining of an early christian church with a modernist abstract expression.</p>
-<!-- /wp:paragraph -->
+For instance, consider this painting of Christ at the altar.
 
-<!-- wp:paragraph -->
-<p>For instance, consider this painting of Christ&nbsp;at the altar.</p>
-<!-- /wp:paragraph -->
+![Christ and Mary at the altar of the church. The style is very modernist.](/assets/images/2015/08/IMG_20150829_113900.jpg)
 
-<!-- wp:image {"id":153,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_113900.jpg"><img src="/assets/images/2015/08/IMG_20150829_113900-760x1024.jpg" alt="Christ and Mary at the altar of the church. The style is very modernist." class="wp-image-153"/></a><figcaption>Christ and Mary at the altar of the church. The style is very modernist.</figcaption></figure>
-<!-- /wp:image -->
+The murals along the walls and ceilings are absolutely stunning. Take a look.
 
-<!-- wp:paragraph -->
-<p>The murals along the walls and ceilings are absolutely stunning. Take a look.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/08/IMG_20150829_114523-760x1024.jpg)
 
-<!-- wp:gallery {"ids":[160,159,158,157,156,155,154]} -->
-<ul class="wp-block-gallery columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_114523-760x1024.jpg" alt="" data-id="160" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_114523/" class="wp-image-160"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_114123-e1440929171895-1024x760.jpg" alt="" data-id="159" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_114123/" class="wp-image-159"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_114056-760x1024.jpg" alt="" data-id="158" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_114056/" class="wp-image-158"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_114014-760x1024.jpg" alt="" data-id="157" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_114014/" class="wp-image-157"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_113946-760x1024.jpg" alt="" data-id="156" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_113946/" class="wp-image-156"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_113921-760x1024.jpg" alt="" data-id="155" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_113921/" class="wp-image-155"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150829_113833-760x1024.jpg" alt="" data-id="154" data-link="http://srikanth.sastry.name/tsarevets-a-photo-essay/img_20150829_113833/" class="wp-image-154"/></figure></li></ul>
-<!-- /wp:gallery -->
+![](/assets/images/2015/08/IMG_20150829_114123-e1440929171895-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>The city seems to have taken this style in pretty well. You can see murals in a similar style all over the city. Here is an example.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/08/IMG_20150829_114056-760x1024.jpg)
 
-<!-- wp:image {"id":163,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="/assets/images/2015/08/IMG_20150829_110451.jpg"><img src="/assets/images/2015/08/IMG_20150829_110451-e1440951390918.jpg" alt="Modernist mural in Veliko Tarnovo" class="wp-image-163"/></a><figcaption>Modernist mural in Veliko Tarnovo</figcaption></figure>
-<!-- /wp:image -->
+![](/assets/images/2015/08/IMG_20150829_114014-760x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>In all, it was a very interesting visit, and worth your time, if you are a history buff.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/08/IMG_20150829_113946-760x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>Oh, and two&nbsp;notable missing images are that of Baldwin's tower and the palace ruins. Unfortunately, I just forgot to photograph them. So here are images from the web as consolation.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/08/IMG_20150829_113921-760x1024.jpg)
 
-<!-- wp:image {"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><a href="https://upload.wikimedia.org/wikipedia/commons/a/a4/Bal.Kyla.jpg"><img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Bal.Kyla.jpg" alt=""/></a><figcaption>Baldwin's tower.</figcaption></figure></div>
-<!-- /wp:image -->
+![](/assets/images/2015/08/IMG_20150829_113833-760x1024.jpg)
 
-<!-- wp:image {"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="https://upload.wikimedia.org/wikipedia/commons/5/57/Veliko_Tarnovo_%28%D0%92%D0%B5%D0%BB%D0%B8%D0%BA%D0%BE_%D0%A2%D1%8A%D1%80%D0%BD%D0%BE%D0%B2%D0%BE%29_-_Tsarevets_%28Palace%29.JPG"><img src="https://upload.wikimedia.org/wikipedia/commons/5/57/Veliko_Tarnovo_%28%D0%92%D0%B5%D0%BB%D0%B8%D0%BA%D0%BE_%D0%A2%D1%8A%D1%80%D0%BD%D0%BE%D0%B2%D0%BE%29_-_Tsarevets_%28Palace%29.JPG" alt=""/></a><figcaption>Ruins of the palace</figcaption></figure></div>
-<!-- /wp:image -->
+The city seems to have taken this style in pretty well. You can see murals in a similar style all over the city. Here is an example.
+
+![Modernist mural in Veliko Tarnovo](/assets/images/2015/08/IMG_20150829_110451.jpg)
+
+In all, it was a very interesting visit, and worth your time, if you are a history buff.
+
+Oh, and two notable missing images are that of Baldwin's tower and the palace ruins. Unfortunately, I just forgot to photograph them. So here are images from the web as consolation.
+
+![Baldwin's tower.](https://upload.wikimedia.org/wikipedia/commons/a/a4/Bal.Kyla.jpg)
+
+![Ruins of the palace](https://upload.wikimedia.org/wikipedia/commons/5/57/Veliko_Tarnovo_%28%D0%92%D0%B5%D0%BB%D0%B8%D0%BA%D0%BE_%D0%A2%D1%8A%D1%80%D0%BD%D0%BE%D0%B2%D0%BE%29_-_Tsarevets_%28Palace%29.JPG)

--- a/_posts/2015-08-31-troyan-monastery.md
+++ b/_posts/2015-08-31-troyan-monastery.md
@@ -4,7 +4,6 @@ title: 'Troyan Monastery'
 date: '2015-08-31T19:26:17-04:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'http://srikanth.sastry.name/?p=258'
 permalink: /troyan-monastery/
 categories:
     - Personal
@@ -14,114 +13,76 @@ tags:
 format: image
 ---
 
-<!-- wp:paragraph -->
-<p>If you are in northern Bulgarian, I recommend stopping by <a href="https://en.wikipedia.org/wiki/Troyan_Monastery">Troyan Monastery</a>.&nbsp;&nbsp;It is definitely worth a couple of hours of your time.</p>
-<!-- /wp:paragraph -->
+If you are in northern Bulgarian, I recommend stopping by [Troyan Monastery](https://en.wikipedia.org/wiki/Troyan_Monastery). It is definitely worth a couple of hours of your time.
 
-<!-- wp:paragraph -->
-<p>Walking up to it, the entrance is fairly simplistic, which is to be expected from a monastery.</p>
-<!-- /wp:paragraph -->
+Walking up to it, the entrance is fairly simplistic, which is to be expected from a monastery.
 
-<!-- wp:image {"id":259,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/troyan-monastery/img_20150831_154933/"><img src="/assets/images/2015/08/IMG_20150831_154933-1024x760.jpg" alt="The entrance to Troyan Monastery; very simple, as expected. However, your attention diverts to the mosaic to the left." class="wp-image-259"/></a><figcaption>The entrance to Troyan Monastery; very simple, as expected. However, your attention diverts to the mosaic to the left.</figcaption></figure></div>
-<!-- /wp:image -->
+![The entrance to Troyan Monastery; very simple, as expected. However, your attention diverts to the mosaic to the left.](/assets/images/2015/08/IMG_20150831_154933-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>The mosaic on top of the left entrance doorway is a new modern day recreation of a roman style mosaic of virgin Mary with baby Christ.</p>
-<!-- /wp:paragraph -->
+The mosaic on top of the left entrance doorway is a new modern day recreation of a roman style mosaic of virgin Mary with baby Christ.
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+![Roman-style mosaic of virgin Mary and baby Christ.](/assets/images/2015/08/IMG_20150831_155017.jpg)
 
-<!-- wp:image {"id":261,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150831_155017.jpg"><img src="/assets/images/2015/08/IMG_20150831_155017-760x1024.jpg" alt="Roman-style mosaic of virgin Mary and baby Christ." class="wp-image-261"/></a><figcaption>Roman-style mosaic of virgin Mary and baby Christ.</figcaption></figure></div>
-<!-- /wp:image -->
+Virgin Mary has a special place in this monastery. The church here is home to the three handed virgin. Here is an [image of it from wikipedia](https://en.wikipedia.org/wiki/Troyan_Monastery#/media/File:Three_Handed_Virgin_of_Troyan_Monastery.JPG).
 
-<!-- wp:paragraph -->
-<p>Virgin Mary has a special place in this monastery. The church here is home to the three handed virgin. Here is an <a href="https://en.wikipedia.org/wiki/Troyan_Monastery#/media/File:Three_Handed_Virgin_of_Troyan_Monastery.JPG">image of it from wikipedia</a>.</p>
-<!-- /wp:paragraph -->
+![Three handed virgin; considered holy in Bulgarian Orthodox Christianity. Maybe the artist was tripping and drew 3 hands, which then became holy. [Image source: wikipedia]](https://upload.wikimedia.org/wikipedia/commons/d/d8/Three_Handed_Virgin_of_Troyan_Monastery.JPG)
 
-<!-- wp:image {"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="https://upload.wikimedia.org/wikipedia/commons/d/d8/Three_Handed_Virgin_of_Troyan_Monastery.JPG"><img src="https://upload.wikimedia.org/wikipedia/commons/d/d8/Three_Handed_Virgin_of_Troyan_Monastery.JPG" alt=""/></a><figcaption>Three handed virgin; considered holy in Bulgarian Orthodox Christianity. Maybe the artist was tripping and drew 3 hands, which then became holy. [Image source: wikipedia]</figcaption></figure></div>
-<!-- /wp:image -->
+The dwellings in the monastery are simple as well.
 
-<!-- wp:paragraph -->
-<p>The dwellings in the monastery are simple as well.</p>
-<!-- /wp:paragraph -->
+![Simple, but adequate, dwellings in the monastery.](/assets/images/2015/08/IMG_20150831_160245.jpg)
 
-<!-- wp:image {"id":264,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150831_160245.jpg"><img src="/assets/images/2015/08/IMG_20150831_160245-1024x760.jpg" alt="Simple, but adequate, dwellings in the monastery." class="wp-image-264"/></a><figcaption>Simple, but adequate, dwellings in the monastery.</figcaption></figure></div>
-<!-- /wp:image -->
+The only splash of "opulence" I saw among the dwellings was this fresco.
 
-<!-- wp:paragraph -->
-<p>The only splash of "opulence" I saw among the dwellings was this&nbsp;fresco.</p>
-<!-- /wp:paragraph -->
+![19th century style fresco among the monastery rooms](/assets/images/2015/08/IMG_20150831_160420.jpg)
 
-<!-- wp:image {"id":265,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150831_160420.jpg"><img src="/assets/images/2015/08/IMG_20150831_160420-1024x760.jpg" alt="19th century style fresco among the monastery rooms" class="wp-image-265"/></a><figcaption>19th century style fresco among the monastery rooms</figcaption></figure></div>
-<!-- /wp:image -->
+However, the church located in the middle is pretty impressive. It built on a low elevation, much like many other churches build during the Ottoman rule. This is largely because the law during the Ottoman rule was that no church should be taller than the mosque in town, and so churches were build at low elevation so that they can build high ceilings without it looming higher than the local mosque.
 
-<!-- wp:paragraph -->
-<p>However, the church located in the middle is pretty impressive. It built on a low elevation, much like many other churches build during the Ottoman rule. This is largely because the law during the Ottoman rule was that no church should be taller than the mosque in town, and so churches were build at low elevation so that they can build high ceilings without it looming higher than the local mosque.</p>
-<!-- /wp:paragraph -->
+Here is are views of the outer walls of the church from the lower ground level, and from a higher elevation.
 
-<!-- wp:paragraph -->
-<p>Here is are views of the outer walls of the church from the lower ground level, and from a higher elevation.</p>
-<!-- /wp:paragraph -->
+[![View of the church from the ground level that is lower than the surrounding land](/assets/images/2015/08/IMG_20150831_155051.jpg)](/assets/images/2015/08/IMG_20150831_155051.jpg)
 
-[![View of the church from the ground level that is lower than the surrounding land](/images/2015/08/IMG_20150831_155051.jpg)](/images/2015/08/IMG_20150831_155051.jpg)
 *View of the church from the ground level that is lower than the surrounding land*
 
-[![View of the church from a higher level (from the patriarchs’ graves)](/images/2015/08/IMG_20150831_160950.jpg)](/images/2015/08/IMG_20150831_160950.jpg)
+[![View of the church from a higher level (from the patriarchs’ graves)](/assets/images/2015/08/IMG_20150831_160950.jpg)](/assets/images/2015/08/IMG_20150831_160950.jpg)
+
 *View of the church from a higher level (from the patriarchs’ graves).*
 
-<!-- wp:paragraph -->
-<p>It is the 19th century frescos that impress the most. The pillars along the entrance walls make a favorable first impression.</p>
-<!-- /wp:paragraph -->
+It is the 19th century frescos that impress the most. The pillars along the entrance walls make a favorable first impression.
 
-[![Notice the paintings along the frieze](/images/2015/08/IMG_20150831_155120.jpg)](/images/2015/08/IMG_20150831_155120.jpg)
+[![Notice the paintings along the frieze](/assets/images/2015/08/IMG_20150831_155120.jpg)](/assets/images/2015/08/IMG_20150831_155120.jpg)
+
 *Notice the paintings along the frieze*
-[![Another view of the frieze along both entrances to the church](/images/2015/08/IMG_20150831_160219.jpg)](/images/2015/08/IMG_20150831_160219.jpg)
+
+[![Another view of the frieze along both entrances to the church](/assets/images/2015/08/IMG_20150831_160219.jpg)](/assets/images/2015/08/IMG_20150831_160219.jpg)
+
 *Another view of the frieze along both entrances to the church*
 
-<!-- wp:paragraph -->
-<p>However, it is the frescos along the walls and ceilings both inside and outside the church that impress the most. While I did not take any photographs of the inside, here is a collection of the frescos on the outside that should give you an inkling of what lies inside the church.</p>
-<!-- /wp:paragraph -->
+However, it is the frescos along the walls and ceilings both inside and outside the church that impress the most. While I did not take any photographs of the inside, here is a collection of the frescos on the outside that should give you an inkling of what lies inside the church.
 
+[![Fresco with a skeleton rowing in a sarcophagus and a fish in it swallowing a person. I have no idea what this is about.](/assets/images/2015/08/IMG_20150831_155159.jpg)](/assets/images/2015/08/IMG_20150831_155159.jpg)
 
-[![Fresco with a skeleton rowing in a sarcophagus and a fish in it swallowing a person. I have no idea what this is about.](/images/2015/08/IMG_20150831_155159.jpg)](/images/2015/08/IMG_20150831_155159.jpg)
 *Fresco with a skeleton rowing in a sarcophagus and a fish in it swallowing a person. I have no idea what this is about.*
-[![This is a continuation of fresco along the ceiling.](/images/2015/08/IMG_20150831_155216.jpg)](/images/2015/08/IMG_20150831_155216.jpg)
+
+[![This is a continuation of fresco along the ceiling.](/assets/images/2015/08/IMG_20150831_155216.jpg)](/assets/images/2015/08/IMG_20150831_155216.jpg)
+
 *This is a continuation of fresco along the ceiling.*
-[![Another fresco at another part of the ceiling.](/images/2015/08/IMG_20150831_155247.jpg)](/images/2015/08/IMG_20150831_155247.jpg)
+
+[![Another fresco at another part of the ceiling.](/assets/images/2015/08/IMG_20150831_155247.jpg)](/assets/images/2015/08/IMG_20150831_155247.jpg)
+
 *Another fresco at another part of the ceiling.*
 
-<!-- wp:paragraph -->
-<p>You will be much more impressed with what's inside the church. It is covered in murals along all walls and&nbsp;ceiling.</p>
-<!-- /wp:paragraph -->
+You will be much more impressed with what's inside the church. It is covered in murals along all walls and ceiling.
 
-<!-- wp:paragraph -->
-<p>At the side of the church, I came across a small entrance with some writing on it.</p>
-<!-- /wp:paragraph -->
+At the side of the church, I came across a small entrance with some writing on it.
 
-<!-- wp:image {"id":271,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150831_160632.jpg"><img src="/assets/images/2015/08/IMG_20150831_160632-1024x760.jpg" alt="A sign that says that inside lies the bones of monks, freedom fighter, and area orthodox christians" class="wp-image-271"/></a><figcaption>A sign that says that inside lies the bones of monks, freedom fighters, and area orthodox christians</figcaption></figure></div>
-<!-- /wp:image -->
+![A sign that says that inside lies the bones of monks, freedom fighters, and area orthodox christians](/assets/images/2015/08/IMG_20150831_160632.jpg)
 
-<!-- wp:paragraph -->
-<p>Based on the sign at the entrance, I had to go see it for myself, and it did not disappoint.</p>
-<!-- /wp:paragraph -->
+Based on the sign at the entrance, I had to go see it for myself, and it did not disappoint.
 
-<!-- wp:image {"id":272,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150831_160549.jpg"><img src="/assets/images/2015/08/IMG_20150831_160549-760x1024.jpg" alt="The bones, as promised." class="wp-image-272"/></a><figcaption>The bones, as promised.</figcaption></figure></div>
-<!-- /wp:image -->
+![The bones, as promised.](/assets/images/2015/08/IMG_20150831_160549.jpg)
 
-<!-- wp:paragraph -->
-<p>The place also has a separate section for the patriarchs' graves, and a bell tower, but it really didn't offer much to an atheist tourist :)</p>
-<!-- /wp:paragraph -->
+The place also has a separate section for the patriarchs' graves, and a bell tower, but it really didn't offer much to an atheist tourist :)
 
-<!-- wp:gallery {"ids":[274,275],"columns":2,"linkTo":"attachment"} -->
-<figure><img src="/assets/images/2015/08/IMG_20150831_161018.jpg" alt="" data-id="274" class="wp-image-274"/></figure>
-<figure><img src="/assets/images/2015/08/IMG_20150831_161112.jpg" alt="" data-id="275" class="wp-image-275"/></figure>
-<!-- /wp:gallery -->
+![](/assets/images/2015/08/IMG_20150831_161018.jpg)
+
+![](/assets/images/2015/08/IMG_20150831_161112.jpg)

--- a/_posts/2015-09-04-sevlievo.md
+++ b/_posts/2015-09-04-sevlievo.md
@@ -4,10 +4,7 @@ title: 'Small town Bulgaria'
 date: '2015-09-04T20:20:24-04:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'http://srikanth.sastry.name/?p=127'
 permalink: /sevlievo/
-fplayout:
-    - fullwidth
 categories:
     - Personal
 tags:
@@ -15,130 +12,86 @@ tags:
     - travel
 ---
 
-<!-- wp:paragraph -->
-<p>I had a really good time visiting Mira's family in <a href="https://en.wikipedia.org/wiki/Sevlievo">Sevlievo, Bulgaria</a>. &nbsp;I am intrigued by the culture and sensibilities in small town Bulgaria.</p>
-<!-- /wp:paragraph -->
+I had a really good time visiting Mira's family in [Sevlievo, Bulgaria](https://en.wikipedia.org/wiki/Sevlievo). I am intrigued by the culture and sensibilities in small town Bulgaria.
 
-<!-- wp:paragraph -->
-<p>We started with visiting the old St. Prophet Eliah Church. The last place I was allowed to take photos was the entrance. It was pretty quaint on the inside, but we were not allowed to take any pictures.</p>
-<!-- /wp:paragraph -->
+We started with visiting the old St. Prophet Eliah Church. The last place I was allowed to take photos was the entrance. It was pretty quaint on the inside, but we were not allowed to take any pictures.
 
-<!-- wp:gallery {"ids":[130,131],"linkTo":"attachment","align":"center","className":"aligncenter"} -->
-<ul class="wp-block-gallery aligncenter columns-2 is-cropped"><li class="blocks-gallery-item"><figure><a href="http://srikanth.sastry.name/sevlievo/img_20150828_100426/"><img src="/assets/images/2015/08/IMG_20150828_100426-768x1024.jpg" alt="" data-id="130" data-link="http://srikanth.sastry.name/sevlievo/img_20150828_100426/" class="wp-image-130"/></a><figcaption>St Prophet Eliah Church</figcaption></figure></li><li class="blocks-gallery-item"><figure><a href="http://srikanth.sastry.name/sevlievo/img_20150828_100506/"><img src="/assets/images/2015/08/IMG_20150828_100506-768x1024.jpg" alt="" data-id="131" data-link="http://srikanth.sastry.name/sevlievo/img_20150828_100506/" class="wp-image-131"/></a><figcaption>Church entrance</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+![St Prophet Eliah Church](/assets/images/2015/08/IMG_20150828_100426-768x1024.jpg)
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+![Church entrance](/assets/images/2015/08/IMG_20150828_100506-768x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>There are a few more churches around the corner, and none are like the churches I am used to seeing in India and in the US.</p>
-<!-- /wp:paragraph -->
+There are a few more churches around the corner, and none are like the churches I am used to seeing in India and in the US.
 
-<!-- wp:gallery {"ids":[186,187]} -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_095912_low-1024x760.jpg" alt="" data-id="186" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_095912_low/" class="wp-image-186"/><figcaption>Another orthodox church</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_095706-1024x760.jpg" alt="" data-id="187" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_095706/" class="wp-image-187"/><figcaption>Yet another orthodox church</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+![Another orthodox church](/assets/images/2015/08/IMG_20150830_095912_low-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>Interestingly, the insignia on one of the church doors, often associated with the Byzantine empire, looked a lot like <a href="https://en.wikipedia.org/wiki/Gandaberunda">Gandaberunda</a>, the official emblem of the state of <a href="https://en.wikipedia.org/wiki/Karnataka">Karnataka</a>.</p>
-<!-- /wp:paragraph -->
+![Yet another orthodox church](/assets/images/2015/08/IMG_20150830_095706-1024x760.jpg)
 
-<!-- wp:gallery {"ids":[194,360],"align":"center"} -->
-<ul class="wp-block-gallery aligncenter columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_095753-775x1024.jpg" alt="" data-id="194" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_095753/" class="wp-image-194"/><figcaption>Notice the double headed eagle on the church door</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2019/01/GBerunda.jpg" alt="" data-id="360" data-link="http://srikanth.sastry.name/sevlievo/gberunda/" class="wp-image-360"/><figcaption>Karnataka state insignia</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+Interestingly, the insignia on one of the church doors, often associated with the Byzantine empire, looked a lot like [Gandaberunda](https://en.wikipedia.org/wiki/Gandaberunda), the official emblem of the state of [Karnataka](https://en.wikipedia.org/wiki/Karnataka).
 
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->
+![Notice the double headed eagle on the church door](/assets/images/2015/08/IMG_20150830_095753-775x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>As I read up more about it, I discovered that two headed birds are ubiquitous in <a href="https://en.wikipedia.org/wiki/Double-headed_eagle">state insignias</a> and <a href="http://www.hubert-herald.nl/TwoHeadedEagle.htm">mythologies</a>.</p>
-<!-- /wp:paragraph -->
+![Karnataka state insignia](/assets/images/2019/01/GBerunda.jpg)
 
-<!-- wp:paragraph -->
-<p>As it turns out, there is a mosque in town as well, but only muslims are allowed in. So this is pretty much all I got to see.</p>
-<!-- /wp:paragraph -->
+As I read up more about it, I discovered that two headed birds are ubiquitous in [state insignias](https://en.wikipedia.org/wiki/Double-headed_eagle) and [mythologies](http://www.hubert-herald.nl/TwoHeadedEagle.htm).
 
-<!-- wp:image {"id":135,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150828_102614.jpg" rel="attachment wp-att-135"><img src="/assets/images/2015/08/IMG_20150828_102614-450x334.jpg" alt="Mosque" class="wp-image-135"/></a><figcaption>The only mosque in town, and we are not allowed in.</figcaption></figure></div>
-<!-- /wp:image -->
+As it turns out, there is a mosque in town as well, but only muslims are allowed in. So this is pretty much all I got to see.
 
-<!-- wp:paragraph -->
-<p>Next, we head to the city center. The old town. Not the most happening place, but nice nevertheless. Mostly clean streets with plenty of space to relax and lounge. Here is a sample of small-town Bulgarian main streets.</p>
-<!-- /wp:paragraph -->
+![The only mosque in town, and we are not allowed in.](/assets/images/2015/08/IMG_20150828_102614.jpg)
 
-<!-- wp:gallery {"ids":[132,134,133,198],"columns":2} -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150828_101405-1024x768.jpg" alt="" data-id="132" data-link="http://srikanth.sastry.name/sevlievo/img_20150828_101405/" class="wp-image-132"/><figcaption>The main street continues on with businesses on either side</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150828_101504-1024x760.jpg" alt="" data-id="134" data-link="http://srikanth.sastry.name/sevlievo/img_20150828_101504/" class="wp-image-134"/><figcaption>Start of a main street in town center largely for pedestrians</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150828_101414-1024x768.jpg" alt="" data-id="133" data-link="http://srikanth.sastry.name/sevlievo/img_20150828_101414/" class="wp-image-133"/><figcaption>The other side of the same main street.</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_094414-1024x760.jpg" alt="" data-id="198" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_094414/" class="wp-image-198"/><figcaption>Notice the wide sidewalk , and benches to sit on.</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+Next, we head to the city center. The old town. Not the most happening place, but nice nevertheless. Mostly clean streets with plenty of space to relax and lounge. Here is a sample of small-town Bulgarian main streets.
 
-<!-- wp:paragraph -->
-<p>The city center also has an impressive statue on a pillar. Apparently, the pillar it stands on is an original Roman pillar from the <a href="https://en.wikipedia.org/wiki/Nicopolis_ad_Istrum">Nicopolis ad Istrum</a>, and the statue was made in Vienna.</p>
-<!-- /wp:paragraph -->
+![The main street continues on with businesses on either side](/assets/images/2015/08/IMG_20150828_101405-1024x768.jpg)
 
-<!-- wp:gallery {"ids":[200,242],"linkTo":"attachment","align":"center"} -->
-<ul class="wp-block-gallery aligncenter columns-2 is-cropped"><li class="blocks-gallery-item"><figure><a href="http://srikanth.sastry.name/sevlievo/img_20150830_093907/"><img src="/assets/images/2015/08/IMG_20150830_093907-763x1024.jpg" alt="" data-id="200" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_093907/" class="wp-image-200"/></a><figcaption>The pillar is from Nicopolis ad Istrum</figcaption></figure></li><li class="blocks-gallery-item"><figure><a href="http://srikanth.sastry.name/img_20150830_093927/"><img src="/assets/images/2015/08/IMG_20150830_093927-1024x780.jpg" alt="" data-id="242" data-link="http://srikanth.sastry.name/img_20150830_093927/" class="wp-image-242"/></a><figcaption>Close up of the statue from Vienna</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+![Start of a main street in town center largely for pedestrians](/assets/images/2015/08/IMG_20150828_101504-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>In true European fashion, Sevlievo is also home to some old european houses that once belonged to the rich, but are now run down, but maintained. I remember seeing similar houses in New Castle Upon Tyne, Madrid, and other old cities in Europe.</p>
-<!-- /wp:paragraph -->
+![The other side of the same main street.](/assets/images/2015/08/IMG_20150828_101414-1024x768.jpg)
 
-<!-- wp:gallery {"ids":[202,203]} -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_093339-1024x760.jpg" alt="" data-id="202" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_093339/" class="wp-image-202"/><figcaption>Medieval aristocrat's dwelling? At least, it looks like it.</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_095233-1024x760.jpg" alt="" data-id="203" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_095233/" class="wp-image-203"/><figcaption>Looks like an old time house whose owner was a rich and influential person.</figcaption></figure></li></ul>
-<!-- /wp:gallery -->
+![Notice the wide sidewalk , and benches to sit on.](/assets/images/2015/08/IMG_20150830_094414-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>Interestingly, Sevlievo is also home to <a href="http://www.bulgariainside.eu/en/articles/Sevlievos-Clock-Tower/542/1">one of the oldest clock towers</a> in Bulgaria, built in 1777/1779.</p>
-<!-- /wp:paragraph -->
+The city center also has an impressive statue on a pillar. Apparently, the pillar it stands on is an original Roman pillar from the [Nicopolis ad Istrum](https://en.wikipedia.org/wiki/Nicopolis_ad_Istrum), and the statue was made in Vienna.
 
-<!-- wp:image {"id":136,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150828_104216.jpg" rel="attachment wp-att-136"><img src="/assets/images/2015/08/IMG_20150828_104216-334x450.jpg" alt="Clock Tower" class="wp-image-136"/></a><figcaption>One of the oldest clock towers in Bulgaria.</figcaption></figure></div>
-<!-- /wp:image -->
+![The pillar is from Nicopolis ad Istrum](/assets/images/2015/08/IMG_20150830_093907-763x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>Moving on, the city also has a "palace of culture", which ironically looks rather drab.</p>
-<!-- /wp:paragraph -->
+![Close up of the statue from Vienna](/assets/images/2015/08/IMG_20150830_093927-1024x780.jpg)
 
-<!-- wp:image {"id":205,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150830_094659.jpg" rel="attachment wp-att-205"><img src="/assets/images/2015/08/IMG_20150830_094659-450x334.jpg" alt="Palace of culture" class="wp-image-205"/></a><figcaption>Palace of culture</figcaption></figure></div>
-<!-- /wp:image -->
+In true European fashion, Sevlievo is also home to some old european houses that once belonged to the rich, but are now run down, but maintained. I remember seeing similar houses in New Castle Upon Tyne, Madrid, and other old cities in Europe.
 
-<!-- wp:paragraph -->
-<p>Speaking of culture, the town also has plenty of monuments and installations from the communist days. I was surprised by the monotony of these installations. Here is a sample to give you an idea of what I mean.</p>
-<!-- /wp:paragraph -->
+![Medieval aristocrat's dwelling? At least, it looks like it.](/assets/images/2015/08/IMG_20150830_093339-1024x760.jpg)
 
-<!-- wp:gallery {"ids":[210,209,208]} -->
-<ul class="wp-block-gallery columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_103142-760x1024.jpg" alt="" data-id="210" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_103142/" class="wp-image-210"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_102617-776x1024.jpg" alt="" data-id="209" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_102617/" class="wp-image-209"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_094731-760x1024.jpg" alt="" data-id="208" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_094731/" class="wp-image-208"/></figure></li></ul>
-<!-- /wp:gallery -->
+![Looks like an old time house whose owner was a rich and influential person.](/assets/images/2015/08/IMG_20150830_095233-1024x760.jpg)
 
-<!-- wp:paragraph -->
-<p>In fact, it appears that everything was pretty monotonous during the communist days. Sevlievo retains some a of communist-era buildings that served as&nbsp;stores and supermarkets. Here are a couple of them.</p>
-<!-- /wp:paragraph -->
+Interestingly, Sevlievo is also home to [one of the oldest clock towers](http://www.bulgariainside.eu/en/articles/Sevlievos-Clock-Tower/542/1) in Bulgaria, built in 1777/1779.
 
-<!-- wp:gallery {"ids":[213,214]} -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_103711-1024x760.jpg" alt="" data-id="213" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_103711/" class="wp-image-213"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_103722-1024x760.jpg" alt="" data-id="214" data-link="http://srikanth.sastry.name/sevlievo/img_20150830_103722/" class="wp-image-214"/></figure></li></ul>
-<!-- /wp:gallery -->
+![One of the oldest clock towers in Bulgaria.](/assets/images/2015/08/IMG_20150828_104216.jpg)
 
-<!-- wp:paragraph -->
-<p>For contrast, compare them to the new bookstore that right down the street.</p>
-<!-- /wp:paragraph -->
+Moving on, the city also has a "palace of culture", which ironically looks rather drab.
 
-<!-- wp:image {"id":215,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150830_103805.jpg" rel="attachment wp-att-215"><img src="/assets/images/2015/08/IMG_20150830_103805-334x450.jpg" alt="The bookstore looks a lot more like in the west." class="wp-image-215"/></a><figcaption>The bookstore looks a lot more like in the west.</figcaption></figure></div>
-<!-- /wp:image -->
+![Palace of culture](/assets/images/2015/08/IMG_20150830_094659.jpg)
 
-<!-- wp:paragraph -->
-<p>Among all the things uniquely Bulgarian, the most intriguing is the death notice. We are all familiar with the <a href="https://en.wikipedia.org/wiki/Obituary">obituary section</a> in the newspapers. In Bulgaria, there are such obituary notices all over town to announce a death, or a death anniversary. For instance, here is a tree that is used as a obituary notice board.</p>
-<!-- /wp:paragraph -->
+Speaking of culture, the town also has plenty of monuments and installations from the communist days. I was surprised by the monotony of these installations. Here is a sample to give you an idea of what I mean.
 
-<!-- wp:image {"id":212,"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="/assets/images/2015/08/IMG_20150830_093301.jpg" rel="attachment wp-att-212"><img src="/assets/images/2015/08/IMG_20150830_093301-334x450.jpg" alt="A tree trunk used as a obituary notice board" class="wp-image-212"/></a><figcaption>A tree trunk used as a obituary notice board.</figcaption></figure></div>
-<!-- /wp:image -->
+![](/assets/images/2015/08/IMG_20150830_103142-760x1024.jpg)
 
-<!-- wp:paragraph -->
-<p>People also post similar notices on the doors of their homes as well, and at times, it is accompanied by a black ribbon tie.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/08/IMG_20150830_102617-776x1024.jpg)
 
-<!-- wp:gallery {"ids":[297,298],"columns":2,"linkTo":"attachment"} -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150830_104750.jpg" alt="" data-id="297" class="wp-image-297"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/08/IMG_20150901_185800.jpg" alt="" data-id="298" class="wp-image-298"/></figure></li></ul>
-<!-- /wp:gallery -->
+![](/assets/images/2015/08/IMG_20150830_094731-760x1024.jpg)
+
+In fact, it appears that everything was pretty monotonous during the communist days. Sevlievo retains some a of communist-era buildings that served as stores and supermarkets. Here are a couple of them.
+
+![](/assets/images/2015/08/IMG_20150830_103711-1024x760.jpg)
+
+![](/assets/images/2015/08/IMG_20150830_103722-1024x760.jpg)
+
+For contrast, compare them to the new bookstore that right down the street.
+
+![The bookstore looks a lot more like in the west.](/assets/images/2015/08/IMG_20150830_103805.jpg)
+
+Among all the things uniquely Bulgarian, the most intriguing is the death notice. We are all familiar with the [obituary section](https://en.wikipedia.org/wiki/Obituary) in the newspapers. In Bulgaria, there are such obituary notices all over town to announce a death, or a death anniversary. For instance, here is a tree that is used as a obituary notice board.
+
+![A tree trunk used as a obituary notice board.](/assets/images/2015/08/IMG_20150830_093301.jpg)
+
+People also post similar notices on the doors of their homes as well, and at times, it is accompanied by a black ribbon tie.
+
+![](/assets/images/2015/08/IMG_20150830_104750.jpg)
+
+![](/assets/images/2015/08/IMG_20150901_185800.jpg)

--- a/_posts/2015-09-04-shipka-memorial-church.md
+++ b/_posts/2015-09-04-shipka-memorial-church.md
@@ -4,7 +4,6 @@ title: 'Shipka Memorial Church'
 date: '2015-09-04T12:20:51-04:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'http://srikanth.sastry.name/?p=282'
 permalink: /shipka-memorial-church/
 categories:
     - Personal
@@ -14,38 +13,28 @@ tags:
     - travel
 ---
 
-<!-- wp:paragraph -->
-<p><a href="https://en.wikipedia.org/wiki/Shipka_Memorial_Church">Shipka memorial church</a> is a Bulgarian Orthodox church built in the style of a Russian Orthodox church.</p>
-<!-- /wp:paragraph -->
+[Shipka memorial church](https://en.wikipedia.org/wiki/Shipka_Memorial_Church) is a Bulgarian Orthodox church built in the style of a Russian Orthodox church.
 
-<!-- wp:image {"id":283,"align":"center","linkDestination":"attachment"} -->
-<div class="wp-block-image"><figure class="aligncenter"><a href="http://srikanth.sastry.name/shipka-memorial-church/img_20150901_134154/"><img src="/assets/images/2015/09/IMG_20150901_134154-334x450.jpg" alt="The front of the Shipka Memorial Church" class="wp-image-283"/></a><figcaption>The front of the Shipka Memorial Church</figcaption></figure></div>
-<!-- /wp:image -->
+![The front of the Shipka Memorial Church](/assets/images/2015/09/IMG_20150901_134154-334x450.jpg)
 
-<!-- wp:paragraph -->
-<p>It was build during late 19th century as a dedication to the Bulgarian, Russian, and Ukrainian soldiers who lost their lives in liberating Bulgaria from the <a href="https://en.wikipedia.org/wiki/Ottoman_Empire">Ottoman empire</a>. The gold plated domes are of typical Muscovite style from the late 19th century.</p>
-<!-- /wp:paragraph -->
+It was build during late 19th century as a dedication to the Bulgarian, Russian, and Ukrainian soldiers who lost their lives in liberating Bulgaria from the [Ottoman empire](https://en.wikipedia.org/wiki/Ottoman_Empire). The gold plated domes are of typical Muscovite style from the late 19th century.
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+![](/assets/images/2015/09/IMG_20150901_134301.jpg)
 
-<!-- wp:gallery {"ids":[284,285,286],"columns":1,"linkTo":"attachment"} -->
-<ul class="wp-block-gallery columns-1 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_134301.jpg" alt="" data-id="284" class="wp-image-284"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135548.jpg" alt="" data-id="285" class="wp-image-285"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135851.jpg" alt="" data-id="286" class="wp-image-286"/></figure></li></ul>
-<!-- /wp:gallery -->
+![](/assets/images/2015/09/IMG_20150901_135548.jpg)
 
-<!-- wp:paragraph -->
-<p>The inside, however, looks a lot like a <a href="https://en.wikipedia.org/wiki/Bulgarian_Orthodox_Church">Bulgarian Orthodox church</a>.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/09/IMG_20150901_135851.jpg)
 
-<!-- wp:gallery {"ids":[290,289,291],"columns":1,"linkTo":"attachment"} -->
-<ul class="wp-block-gallery columns-1 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135343.jpg" alt="" data-id="290" class="wp-image-290"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135329.jpg" alt="" data-id="289" class="wp-image-289"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135423.jpg" alt="" data-id="291" class="wp-image-291"/></figure></li></ul>
-<!-- /wp:gallery -->
+The inside, however, looks a lot like a [Bulgarian Orthodox church](https://en.wikipedia.org/wiki/Bulgarian_Orthodox_Church).
 
-<!-- wp:paragraph -->
-<p>There is a crypt in the basement that has graves that serves as a memorial for and contains remains of&nbsp;the soldiers who lost their lives in <a href="https://en.wikipedia.org/wiki/Battle_of_Shipka_Pass">battles of Shipka Pass</a> during the <a href="https://en.wikipedia.org/wiki/Russo-Turkish_War_(1877%E2%80%9378)">Russo-Turkish war</a>.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2015/09/IMG_20150901_135343.jpg)
 
-<!-- wp:gallery {"ids":[294,293],"columns":1,"linkTo":"attachment"} -->
-<ul class="wp-block-gallery columns-1 is-cropped"><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135137.jpg" alt="" data-id="294" class="wp-image-294"/></figure></li><li class="blocks-gallery-item"><figure><img src="/assets/images/2015/09/IMG_20150901_135040.jpg" alt="" data-id="293" class="wp-image-293"/></figure></li></ul>
-<!-- /wp:gallery -->
+![](/assets/images/2015/09/IMG_20150901_135329.jpg)
+
+![](/assets/images/2015/09/IMG_20150901_135423.jpg)
+
+There is a crypt in the basement that has graves that serves as a memorial for and contains remains of the soldiers who lost their lives in [battles of Shipka Pass](https://en.wikipedia.org/wiki/Battle_of_Shipka_Pass) during the [Russo-Turkish war](https://en.wikipedia.org/wiki/Russo-Turkish_War_(1877%E2%80%9378)).
+
+![](/assets/images/2015/09/IMG_20150901_135137.jpg)
+
+![](/assets/images/2015/09/IMG_20150901_135040.jpg)

--- a/_posts/2019-08-21-when-should-you-build-for-survival.md
+++ b/_posts/2019-08-21-when-should-you-build-for-survival.md
@@ -4,7 +4,6 @@ title: 'When should you build for survival?'
 date: '2019-08-21T14:23:48-04:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'https://srikanth.sastry.name/?p=461'
 permalink: /when-should-you-build-for-survival/
 categories:
     - Professional
@@ -14,126 +13,60 @@ tags:
 image: /assets/images/2019/08/Are-You-Succeeding-Blog-thegem-blog-default-1024x512.jpg
 ---
 
-<!-- wp:image {"align":"center","id":463} -->
-<!-- <div class="wp-block-image"><figure class="aligncenter"><img src="/assets/images/2019/08/Are-You-Succeeding-Blog-thegem-blog-default-1024x512.jpg" alt="" class="wp-image-463"/><!-- <figcaption>source: http://beaconbusinessmarketing.com/success-vs-survival/</figcaption> --> </figure></div> -->
-<!-- /wp:image -->
+Previously, I wrote about [building for survival vs. success]({% post_url 2019-08-15-are-you-building-for-survival-or-excellence %}) building for survival vs. success. Briefly, when building for survival, your only goal to get the product working for the specific usecase, and in contrast, when building for success, you are building to solve a bigger class of problems within the broader context of your solution space. In this post, I will talk about when you should be [build for survival, and when for success](/garden/survival-vs-excellence-modes/).
 
-<!-- wp:paragraph -->
-Previously, I wrote about [building for survival vs. success]({% post_url 2019-08-15-are-you-building-for-survival-or-excellence %}) building for survival vs. success. Briefly, when building for survival, your only goal to get the product working for the specific usecase, and in contrast, when building for success, you are building to solve a bigger class of problems within the broader context of your solution space. In this post, I will talk about when you should be <a href="/garden/survival-vs-excellence-modes/">build for survival, and when for success</a>.
-<!-- /wp:paragraph -->
+## A Straw Man
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+![](/assets/images/2019/08/Meet-You-Strawman.jpg)
 
-<!-- wp:heading -->
-<h2>A Straw Man</h2>
-<!-- /wp:heading -->
+On the face of it, it seems like an easy answer: "*build for survival, when survival is at stake; otherwise, build for success.*" But unfortunately, that answer hides a multitude of assumptions, and oversimplifies the real-world within which the software development process operates. So, let's first breakdown the assumptions, and then address the oversimplification.
 
-<!-- wp:image {"align":"center","id":464,"width":349,"height":262} -->
-<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/assets/images/2019/08/Meet-You-Strawman.jpg" alt="" class="wp-image-464" width="349" height="262"/><!--<figcaption>source: https://prepareforchange.net/images/2016/06/Meet-You-Strawman.jpg</figcaption>--></figure></div>
-<!-- /wp:image -->
+### The assumptions
 
-<!-- wp:paragraph -->
-<p>On the face of it, it seems like an easy answer: "<em>build for survival, when survival is at stake; otherwise, build for success.</em>" But unfortunately, that answer hides a multitude of assumptions, and oversimplifies the real-world within which the software development process operates. So, let's first breakdown the assumptions, and then address the oversimplification.</p>
-<!-- /wp:paragraph -->
+The first assumption here is the notion that we have a common understanding of what it means to say that a project/product's "survival is at stake". And the second assumption is that building for survival in all such cases will actually help.
 
-<!-- wp:heading {"level":3} -->
-<h3>The assumptions</h3>
-<!-- /wp:heading -->
+#### Is your survival at stake?
 
-<!-- wp:paragraph -->
-<p>The first assumption here is the notion that we have a common understanding of what it means to say that a project/product's "survival is at stake". And the second assumption is that building for survival in all such cases will actually help. </p>
-<!-- /wp:paragraph -->
+ Let's examine the first assumption: *we can agree on what it means for survival to be at stake.* Sure, in the extreme cases, we can all agree on this notion (e.g., a startup has a runway of 6 months, and additional funding depends on delivering an alpha in 3 months), but moving past that, things become a lot more subjective.
 
-<!-- wp:heading {"level":4} -->
-<h4>Is your survival at stake?</h4>
-<!-- /wp:heading -->
+Consider a new project/product incubating within a well established company such as Facebook or Google. Is it's survival ever at stake? How about a project that involves building/dismantling infrastructure with a fixed, slightly aggressive, deadline; would it's survival be at stake? The answers to the above questions are not always obvious, and they can be different depending on who you ask. They can differ depending on where you are in the organizational hierarchy; it can even differ among developers within the team.
 
-<!-- wp:paragraph -->
-<p> Let's examine the first assumption: <em>we can agree on what it means for survival to be at stake.</em> Sure, in the extreme cases, we can all agree on this notion (e.g., a startup has a runway of 6 months, and additional funding depends on delivering an alpha in 3 months), but moving past that, things become a lot more subjective. </p>
-<!-- /wp:paragraph -->
+#### Ok, so your survival is at stake. So should you build for survival?
 
-<!-- wp:paragraph -->
-<p>Consider a new project/product incubating within a well established company such as Facebook or Google. Is it's survival ever at stake? How about a project that involves building/dismantling infrastructure with a fixed, slightly aggressive, deadline; would it's survival be at stake? The answers to the above questions are not always obvious, and they can be different depending on who you ask. They can differ depending on where you are in the organizational hierarchy; it can even differ among developers within the team. </p>
-<!-- /wp:paragraph -->
+Now on to the second assumption: *when survival is at stake, building for survival is actually the right thing to do*. Again, there are some obvious cases where this is the right call. What about a case where the survival of your medical diagnostic software is at stake; would building for survival actually be the right thing (given that 'break things' is a corollary of 'move fast')? How about when you realize that you were a little too optimistic about what the product could accomplish with the limited resources you have; is building for survival still the right thing (ask Microsoft about Windows Vista)?
 
-<!-- wp:heading {"level":4} -->
-<h4>Ok, so your survival is at stake. So should you build for survival?</h4>
-<!-- /wp:heading -->
+The oversimplification made here is that we only ever have two choices: survival, or success. This is almost never the case. You can almost always negotiate. You can negotiate on deadlines, on scope, on resources, on expectations, and on outcomes. Without taking all of the above into account, the discussion of survival vs success is meaningless.
 
-<!-- wp:paragraph -->
-<p>Now on to the second assumption: <em>when survival is at stake, building for survival is actually the right thing to do</em>. Again, there are some obvious cases where this is the right call. What about a case where the survival of your medical diagnostic software is at stake; would building for survival actually be the right thing (given that 'break things' is a corollary of 'move fast')?  How about when you realize that you were a little too optimistic about what the product could accomplish with the limited resources you have; is building for survival still the right thing (ask Microsoft about Windows Vista)?</p>
-<!-- /wp:paragraph -->
+## So, when should you build for survival vs success?
 
-<!-- wp:paragraph -->
-<p>The oversimplification made here is that we only ever have two choices: survival, or success. This is almost never the case. You can almost always negotiate. You can negotiate on deadlines, on scope, on resources, on expectations, and on outcomes. Without taking all of the above into account, the discussion of survival vs success is meaningless. </p>
-<!-- /wp:paragraph -->
+While you have to evaluate every situation independently and holistically to determine which approach is the right one to take, here are some rule-of-thumb symptoms that suggest that you should be building for survival.
 
-<!-- wp:heading -->
-<h2>So, when should you build for survival vs success?</h2>
-<!-- /wp:heading -->
+### You are resource constrained, and failure is an option
 
-<!-- wp:paragraph -->
-<p>While you have to evaluate every situation independently and holistically to determine which approach is the right one to take, here are some rule-of-thumb symptoms that suggest that you should be building for survival.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2019/08/product-resource-graphic01.png)
 
-<!-- wp:heading {"level":3} -->
-<h3>You are resource constrained, and failure is an option</h3>
-<!-- /wp:heading -->
+When you are resource constrained, then there is a good chance that you cannot afford the time/effort/resources that a principled approach to software development demands. Recall, that in such a case, I talked about renegotiating the original parameters and expectations. However, they are not always negotiable. (*E.g.*, you might have only a few months' of runway, and your investor might not be willing to fund you in case of milestone slippage.) In such cases, failure becomes a better option than renegotiation (almost vacuously). Here, building of survival makes sense.
 
-<!-- wp:image {"align":"center","id":465,"width":234,"height":156} -->
-<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/assets/images/2019/08/product-resource-graphic01.png" alt="" class="wp-image-465" width="234" height="156"/><!-- <figcaption>source: https://www.triskellsoftware.com/images/2016/01/product-resource-graphic01.png</figcaption> --></figure></div>
-<!-- /wp:image -->
+### Your environment is highly uncertain
 
-<!-- wp:paragraph -->
-<p>When you are resource constrained, then there is a good chance that you cannot afford the time/effort/resources that a principled approach to software development demands. Recall, that in such a case, I talked about renegotiating the original parameters and expectations. However, they are not always negotiable. (<em>E.g.</em>, you might have only a few months' of runway, and your investor might not be willing to fund you in case of milestone slippage.) In such cases, failure becomes a better option than renegotiation (almost vacuously). Here, building of survival makes sense.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2019/08/Uncertainty-Reigns-Supreme-for-Fixed-Income-Investors-in-2015-e1505506674364.png)
 
-<!-- wp:heading {"level":3} -->
-<h3>Your environment is highly uncertain</h3>
-<!-- /wp:heading -->
+High uncertainty is often a good trigger to build for survival. High uncertainty often requires you to 'fail fast'. If you are working on experimental technology, or on nascent problem spaces, there really isn't much to grok without actually building something and test things out. In other cases, it might not be possible to know if you are solving the right problem; this happens often when your customers tend to "know it when they see it".
 
-<!-- wp:image {"align":"center","id":466,"width":349,"height":349} -->
-<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/assets/images/2019/08/Uncertainty-Reigns-Supreme-for-Fixed-Income-Investors-in-2015-e1505506674364.png" alt="" class="wp-image-466" width="349" height="349"/> <!-- <figcaption>source: https://blogs.cfainstitute.org/investor/2015/09/08/uncertainty-reigns-supreme-for-fixed-income-investors-in-2015/</figcaption> --> </figure></div>
-<!-- /wp:image -->
+### Your survival is more important than stakeholders' risks
 
-<!-- wp:paragraph -->
-<p>High uncertainty is often a good trigger to build for survival. High uncertainty often requires you to 'fail fast'. If you are working on experimental technology, or on nascent problem spaces, there really isn't much to grok without actually building something and test things out. In other cases, it might not be possible to know if you are solving the right problem; this happens often when your customers tend to "know it when they see it".</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2019/08/stakeholders.png)
 
-<!-- wp:heading {"level":3} -->
-<h3>Your survival is more important than stakeholders' risks</h3>
-<!-- /wp:heading -->
+This one is less obvious. It could well be the case that your survival is at stake, you are resource constrained, and there is no negotiating. However, there still are situations when you should not build for survival. One big situation is when the stakeholders' risks trump your survival.
 
-<!-- wp:image {"align":"center","id":467,"width":376,"height":349} -->
-<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="/assets/images/2019/08/stakeholders.png" alt="" class="wp-image-467" width="376" height="349"/> <!-- <figcaption>source: https://corporatefinanceinstitute.com/resources/knowledge/finance/stakeholder/</figcaption> --> </figure></div>
-<!-- /wp:image -->
+The most egregious example I can think of is in medical technology. If you software you are building is for (say) medical diagnosis, and a wrong diagnosis can mean the difference between life and death of a patient, then you should never, ever, ever build for survival. From here, you can extrapolate to all other situations where your stakeholders' risk outweighs yours.
 
-<!-- wp:paragraph -->
-<p>This one is less obvious. It could well be the case that your survival is at stake, you are resource constrained, and there is no negotiating. However, there still are situations when you should not build for survival. One big situation is when the stakeholders' risks trump your survival.</p>
-<!-- /wp:paragraph -->
+### You are solving a one-time problem
 
-<!-- wp:paragraph -->
-<p>The most egregious example I can think of is in medical technology. If you software you are building is for (say) medical diagnosis, and a wrong diagnosis can mean the difference between life and death of a patient, then you should never, ever, ever build for survival. From here, you can extrapolate to all other situations where your stakeholders' risk outweighs yours.</p>
-<!-- /wp:paragraph -->
+![](/assets/images/2019/08/Throw-away-Prototyping-Model.jpg)
 
-<!-- wp:heading {"level":3} -->
-<h3>You are solving a one-time problem</h3>
-<!-- /wp:heading -->
+This one is tricky, because solutions to one-time problems have a nasty tendency of sticking around a lot longer than they should. However, in principle, if you are writing software that is going to be used just once, and then discarded, then you should consider building for survival. However, please ensure that that software will NOT persist past it's primary use. Incidentally, if your work involves building prototypes and proof-of-concept works, then you are almost definitely building for survival.
 
-<!-- wp:image {"align":"center","id":468} -->
-<div class="wp-block-image"><figure class="aligncenter"><img src="/assets/images/2019/08/Throw-away-Prototyping-Model.jpg" alt="" class="wp-image-468"/> <!-- <figcaption>source: https://prototypeinfo.com/evolutionary-prototyping-and-throw-away-prototyping/</figcaption>  --> </figure></div>
-<!-- /wp:image -->
+There are multiple ways to enforce this: (1) do not put it into version control at all, (2) put the code in a new repo that is nuked on a timer, (3) prevent importing modules from this codebase to anywhere else, *etc*.
 
-<!-- wp:paragraph -->
-<p>This one is tricky, because solutions to one-time problems have a nasty tendency of sticking around a lot longer than they should. However, in principle, if you are writing software that is going to be used just once, and then discarded, then you should consider building for survival. However, please ensure that that software will NOT persist past it's primary use. Incidentally, if your work involves building prototypes and proof-of-concept works, then you are almost definitely building for survival.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>There are multiple ways to enforce this: (1) do not put it into version control at all, (2) put the code in a new repo that is nuked on a timer, (3) prevent importing modules from this codebase to anywhere else, <em>etc</em>.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Can you think of any other situations where building for survival is warranted? Let me know in the comments.</p>
-<!-- /wp:paragraph -->
+Can you think of any other situations where building for survival is warranted? Let me know in the comments.

--- a/_posts/2019-12-31-responding-to-concerns-as-a-people-manager.md
+++ b/_posts/2019-12-31-responding-to-concerns-as-a-people-manager.md
@@ -4,7 +4,6 @@ title: 'Responding to concerns as a people manager'
 date: '2019-12-31T20:58:18-05:00'
 author: 'Srikanth Sastry'
 layout: post
-guid: 'https://srikanth.sastry.name/?p=503'
 permalink: /responding-to-concerns-as-a-people-manager/
 image: /assets/images/2019/12/unhappy-389944_1920-740x430.jpg
 categories:
@@ -13,122 +12,70 @@ tags:
     - 'People management'
 ---
 
-<!-- wp:paragraph -->
-<p>You are the people manager for a team, and a team member comes to you with a concern. How should you approach it? I have been in this situation multiple times, and have admittedly made some wrong turns. After some corrections and learning, here is what seems to work well for me (although YMMV). If you like lists, here is a snapshot of the path I take.</p>
-<!-- /wp:paragraph -->
+You are the people manager for a team, and a team member comes to you with a concern. How should you approach it? I have been in this situation multiple times, and have admittedly made some wrong turns. After some corrections and learning, here is what seems to work well for me (although YMMV). If you like lists, here is a snapshot of the path I take.
 
-<!-- wp:list {"ordered":true} -->
-<ol><li>Listen</li><li>Empathize</li><li>Don't take notes</li><li>Descend into the particular</li><li><a href="/garden/check-if-concern-is-systemic/">Check with others</a></li><li>Socialize, if the issue is common</li><li>DO NOT become an <a href="/garden/explaining-away-concerns-is-victim-blaming/">apologist for status quo</a></li></ol>
-<!-- /wp:list -->
+1. Listen
+2. Empathize
+3. Don't take notes
+4. Descend into the particular
+5. [Check with others](/garden/check-if-concern-is-systemic/)
+6. Socialize, if the issue is common
+7. DO NOT become an [apologist for status quo](/garden/explaining-away-concerns-is-victim-blaming/)
 
-<!-- wp:paragraph -->
-<p>Note that this doesn’t talk about the resolution for the issue. That is very specific to the issue at hand. What I have is more of an <a href="/garden/concern-response-framework/">approach to understanding the issue</a> in a manner that is respectful of the stakeholders. With that disclaimer, let’s unpack each of those bullet points.</p>
-<!-- /wp:paragraph -->
+Note that this doesn’t talk about the resolution for the issue. That is very specific to the issue at hand. What I have is more of an [approach to understanding the issue](/garden/concern-response-framework/) in a manner that is respectful of the stakeholders. With that disclaimer, let’s unpack each of those bullet points.
 
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
+## Listen
 
-<!-- wp:heading -->
-<h2>Listen</h2>
-<!-- /wp:heading -->
+![Source: https://richmondmom.com/2017/02/22/what-i-say-and-what-my-kids-hear/](/assets/images/2019/12/what-kids-hear.jpg)
 
-<!-- wp:image {"align":"left","id":510,"sizeSlug":"full"} -->
-<div class="wp-block-image"><figure class="alignleft size-full"><img src="/assets/images/2019/12/what-kids-hear.jpg" alt="" class="wp-image-510"/><figcaption>Source: https://richmondmom.com/2017/02/22/what-i-say-and-what-my-kids-hear/</figcaption></figure></div>
-<!-- /wp:image -->
+When someone in the team you support talks about how things are not a 100%, just listen. And I mean really listen. Take what they are saying at face value, even if you suspect something else is at play. Be non judgmental. Give full attention here. This is a lot harder than it sounds! Beware of you mind trying to make connections with that you are hearing. Resist that impulse. Repeat back to them what they said, but in your own words. Ask for a confirmation if you have captured their thoughts and feelings well. Rinse and repeat until they respond affirmatively.
 
-<!-- wp:paragraph -->
-<p>When someone in the team you support talks about how things are not a 100%, just listen. And I mean really listen. Take what they are saying at face value, even if you suspect something else is at play. Be non judgmental. Give full attention here. This is a lot harder than it sounds! Beware of you mind trying to make connections with that you are hearing. Resist that impulse. Repeat back to them what they said, but in your own words. Ask for a confirmation if you have captured their thoughts and feelings well. Rinse and repeat until they respond affirmatively.</p>
-<!-- /wp:paragraph -->
+## Empathize
 
-<!-- wp:heading -->
-<h2>Empathize</h2>
-<!-- /wp:heading -->
+![source: https://www.pxfuel.com/en/free-photo-qwnsc](/assets/images/2019/12/pxfuel.com_-1024x683.jpg)
 
-<!-- wp:image {"id":512,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="/assets/images/2019/12/pxfuel.com_-1024x683.jpg" alt="" class="wp-image-512"/><figcaption>source: https://www.pxfuel.com/en/free-photo-qwnsc</figcaption></figure>
-<!-- /wp:image -->
+Now that you know what the team member is talking about, do not respond yet. Stop to empathize with them, or their situation. Even if you do not agree with them, still take the time to understand where they are coming from and why they are feeling the way they are. Talk to them to make sure you do understand where they are coming from. It is important not to come across as someone with all the answers, or worse, with condescension. It is important that the person feels validated and not diminished for sharing what they did share. Not giving them that luxury is a sure way to get them to express themselves less and hold things within themselves until it gets to a point where they decide to leave.
 
-<!-- wp:paragraph -->
-<p>Now that you know what the team member is talking about, do not respond yet. Stop to empathize with them, or their situation. Even if you do not agree with them, still take the time to understand where they are coming from and why they are feeling the way they are. Talk to them to make sure you do understand where they are coming from. It is important not to come across as someone with all the answers, or worse, with condescension. It is important that the person feels validated and not diminished for sharing what they did share. Not giving them that luxury is a sure way to get them to express themselves less and hold things within themselves until it gets to a point where they decide to leave.</p>
-<!-- /wp:paragraph -->
+## Don't take notes
 
-<!-- wp:heading -->
-<h2>Don't take notes</h2>
-<!-- /wp:heading -->
+[![Original Image by StartupStockPhotos from Pixabay](/assets/images/2019/12/Untitled-presentation.png)](https://pixabay.com/users/StartupStockPhotos-690514/?utm_source=link-attribution&utm_medium=referral&utm_campaign=image&utm_content=593333)
 
-<!-- wp:image {"id":514,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="/assets/images/2019/12/Untitled-presentation.png" alt="" class="wp-image-514"/><figcaption>Original Image by <a href="https://pixabay.com/users/StartupStockPhotos-690514/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=593333">StartupStockPhotos</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=593333">Pixabay</a></figcaption></figure>
-<!-- /wp:image -->
+Really, put your pen, phone, laptop (or whatever you use to take notes) down. Taking notes during this process does harm on two fronts: (1) it impedes your listening and your ability to empathize, and (2) it can have a chilling effect on the other person's candor.
 
-<!-- wp:paragraph -->
-<p>Really, put your pen, phone, laptop (or whatever you use to take notes) down. Taking notes during this process does harm on two fronts: (1) it impedes your listening and your ability to empathize, and (2) it can have a chilling effect on the other person's candor.</p>
-<!-- /wp:paragraph -->
+When you start taking notes on what you are hearing, your brain stops listening because it's too focused on ensuring that what it hears is making it into the notes. This directly impacts empathy in that when you don't listen, you cannot empathize. You might think that by the other person see you take notes, they get the impression/message that you care and you want to make sure nothing is lost/forgotten. However, when it comes to matters where they want to be heard as much as they want their concern addressed, they are looking for a real conversation, and taking notes decidedly gets in the way.
 
-<!-- wp:paragraph -->
-<p>When you start taking notes on what you are hearing, your brain stops listening because it's too focused on ensuring that what it hears is making it into the notes. This directly impacts empathy in that when you don't listen, you cannot empathize. You might think that by the other person see you take notes, they get the impression/message that you care and you want to make sure nothing is lost/forgotten. However, when it comes to matters where they want to be heard as much as they want their concern addressed, they are looking for a real conversation, and taking notes decidedly gets in the way.</p>
-<!-- /wp:paragraph -->
+Many such conversations where a team member is bringing a concern comes with an automatic expectation of some form of confidentiality and discretion; otherwise, they would have brought this up in a group and not in private. The moment you start taking notes, you are giving the impression that everything they are saying is 'on the record and in writing' so to speak. This makes the speaker guarded; they no longer feel comfortable speaking in a fluent stream of thoughts; they might feel the need to measure their words lest it be misinterpreted from the notes.
 
-<!-- wp:paragraph -->
-<p>Many such conversations where a team member is bringing a concern comes with an automatic expectation of some form of confidentiality and discretion; otherwise, they would have brought this up in a group and not in private. The moment you start taking notes, you are giving the impression that everything they are saying is 'on the record and in writing' so to speak. This makes the speaker guarded; they no longer feel comfortable speaking in a fluent stream of thoughts; they might feel the need to measure their words lest it be misinterpreted from the notes.</p>
-<!-- /wp:paragraph -->
+## Descend into the particular
 
-<!-- wp:heading -->
-<h2>Descend into the particular</h2>
-<!-- /wp:heading -->
+[![Image by Gerd Altmann from Pixabay](/assets/images/2019/12/apple-1594742_1920-1024x378.jpg)](https://pixabay.com/users/geralt-9301/?utm_source=link-attribution&utm_medium=referral&utm_campaign=image&utm_content=1594742)
 
-<!-- wp:image {"id":515,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="/assets/images/2019/12/apple-1594742_1920-1024x378.jpg" alt="" class="wp-image-515"/><figcaption>Image by <a href="https://pixabay.com/users/geralt-9301/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1594742">Gerd Altmann</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1594742">Pixabay</a></figcaption></figure>
-<!-- /wp:image -->
+After hearing the person out, remain focused on the specific issue they are bringing up. Do not try to generalize. By generalizing you risk losing important details that might be critical to addressing the issue. Also, when it comes to such issues, it helps to solve the exact problem at hand first, and then look to address the general case outside the scope of what the team member is bringing up.
 
-<!-- wp:paragraph -->
-<p>After hearing the person out, remain focused on the specific issue they are bringing up. Do not try to generalize. By generalizing you risk losing important details that might be critical to addressing the issue. Also, when it comes to such issues, it helps to solve the exact problem at hand first, and then look to address the general case outside the scope of what the team member is bringing up.</p>
-<!-- /wp:paragraph -->
+For instance, I had a team member come up to me and say that their lead engineer was micromanaging them too much. The lead would literally look over the engineer's shoulder and insist that the engineer do things exactly the way the lead wanted them to do it. To get away from the lead, the engineer started working away from their desk, but the lead ended up following them to where ever the engineer was and proceeded with the same behavior. Here the engineer is coming to me for a solution for this particular issue, and it does not help for me to start thinking about generalities such as hostile work environments, issues of gender and under-represented minorities, or workplace aggression. Instead, I chose to focus on the two individuals involved, and the current situation that needed addressing. I strongly recommend you do the same!
 
-<!-- wp:paragraph -->
-<p>For instance, I had a team member come up to me and say that their lead engineer was micromanaging them too much. The lead would literally look over the engineer's shoulder and insist that the engineer do things exactly the way the lead wanted them to do it. To get away from the lead, the engineer started working away from their desk, but the lead ended up following them to where ever the engineer was and proceeded with the same behavior. Here the engineer is coming to me for a solution for this particular issue, and it does not help for me to start thinking about generalities such as hostile work environments, issues of gender and under-represented minorities, or workplace aggression. Instead, I chose to focus on the two individuals involved, and the current situation that needed addressing. I strongly recommend you do the same!</p>
-<!-- /wp:paragraph -->
+## Check with others
 
-<!-- wp:heading -->
-<h2>Check with others</h2>
-<!-- /wp:heading -->
+[![Image by Free-Photos from Pixabay](/assets/images/2019/12/workplace-1245776_1920-1024x683.jpg)](https://pixabay.com/photos/?utm_source=link-attribution&utm_medium=referral&utm_campaign=image&utm_content=1245776)
 
-<!-- <figure><img src="/assets/images/2019/12/listen-1702648_1920-1024x682.jpg" alt="" data-id="517" data-full-url="/assets/images/2019/12/listen-1702648_1920.jpg" data-link="https://srikanth.sastry.name/?attachment_id=517" class="wp-image-517" /><figcaption class="blocks-gallery-item__caption">Image by <a href="https://pixabay.com/users/jamesoladujoye-3409212/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1702648">jamesoladujoye</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1702648">Pixabay</a></figcaption></figure>
-<figure><img src="/assets/images/2019/12/people-2557396_1920-1024x683.jpg" alt="" data-id="518" data-full-url="/assets/images/2019/12/people-2557396_1920.jpg" data-link="https://srikanth.sastry.name/?attachment_id=518" class="wp-image-518" /><figcaption class="blocks-gallery-item__caption">Image by <a href="https://pixabay.com/users/StockSnap-894430/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=2557396">StockSnap</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=2557396">Pixabay</a></figcaption></figure> -->
-<figure><img src="/assets/images/2019/12/workplace-1245776_1920-1024x683.jpg" alt="" data-id="519" data-full-url="/assets/images/2019/12/workplace-1245776_1920.jpg" data-link="https://srikanth.sastry.name/?attachment_id=519" class="wp-image-519" /><figcaption class="blocks-gallery-item__caption">Image by <a href="https://pixabay.com/photos/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1245776">Free-Photos</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=1245776">Pixabay</a></figcaption></figure>
+So, you listened, empathized, kept your focus on the issue at hand. Next, we start trying to resolve it no? No! Don’t try to solve the issue yet. Check with others to see the issue is more widespread than the single individual.
 
-<!-- wp:paragraph -->
-<p>So, you listened, empathized, kept your focus on the issue at hand. Next, we start trying to resolve it no? No! Don’t try to solve the issue yet. Check with others to see the issue is more widespread than the single individual. </p>
-<!-- /wp:paragraph -->
+There are multiple ways to do this, and it really depends on the issue at hand. You can bring it up with others in various contexts and situations, but be sure to respect the original team member’s privacy and discretion. And do this urgently. Letting too much time go by sends the wrong signal to the person who brought up the issue in the first place.
 
-<!-- wp:paragraph -->
-<p>There are multiple ways to do this, and it really depends on the issue at hand. You can bring it up with others in various contexts and situations, but be sure to respect the original team member’s privacy and discretion. And do this urgently. Letting too much time go by sends the wrong signal to the person who brought up the issue in the first place.</p>
-<!-- /wp:paragraph -->
+By checking with others you get an important signal. Is the issue singular int hat it is just this individual facing it, or is it an issue that multiple people are facing it, but one only of them brought it to you attention. This signal has a strong bearing on which way to proceed next.
 
-<!-- wp:paragraph -->
-<p>By checking with others you get an important signal. Is the issue singular int hat it is just this individual facing it, or is it an issue that multiple people are facing it, but one only of them brought it to you attention. This signal has a strong bearing on which way to proceed next.</p>
-<!-- /wp:paragraph -->
+## Socialize, if the issue is common
 
-<!-- wp:heading -->
-<h2>Socialize, if the issue is common</h2>
-<!-- /wp:heading -->
+![](/assets/images/2019/12/F6A7AB0B-9B1F-4081-8F7A-5C1E36C3123D-1024x683.jpeg)
 
-<!-- wp:image {"id":522,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="/assets/images/2019/12/F6A7AB0B-9B1F-4081-8F7A-5C1E36C3123D-1024x683.jpeg" alt="" class="wp-image-522"/></figure>
-<!-- /wp:image -->
+If you find that the issue raised actually affects more than one individual, it is important to socialize it. It conveys that the organization is willing to engage in difficult conversation for employees' benefit, and it is important that everyone sees that. Of course, you have to mean it, and actually follow up with actions that address the issue.
 
-<!-- wp:paragraph -->
-<p>If you find that the issue raised actually affects more than one individual, it is important to socialize it. It conveys that the organization is willing to engage in difficult conversation for employees' benefit, and it is important that everyone sees that. Of course, you have to mean it, and actually follow up with actions that address the issue.</p>
-<!-- /wp:paragraph -->
+## DO NOT become an apologist
 
-<!-- wp:heading -->
-<h2>DO NOT become an apologist </h2>
-<!-- /wp:heading -->
+![](/assets/images/2019/12/77DCDE52-6137-447C-92B4-CB09E82F11C0-1024x678.jpeg)
 
-<!-- wp:image {"id":528,"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="/assets/images/2019/12/77DCDE52-6137-447C-92B4-CB09E82F11C0-1024x678.jpeg" alt="" class="wp-image-528"/></figure>
-<!-- /wp:image -->
+This is a strong temptation. Given what you know about how your organization and your leadership works, you might want to explain how the issue arose due to misunderstandings, or how the person who brought up the issue is misinterpreting things, or how things really are working the way things should and all that this person needs is a little faith and patience, etc. The argument doesn’t matter. The mistake is to make any such argument at all.
 
-<!-- wp:paragraph -->
-<p>This is a strong temptation. Given what you know about how your organization and your leadership works, you might want to explain how the issue arose due to misunderstandings, or how the person who brought up the issue is misinterpreting things, or how things really are working the way things should and all that this person needs is a little faith and patience, etc. The argument doesn’t matter. The mistake is to make any such argument at all. <br />By becoming an apologist for the status quo, you are effectively victim-blaming. You are telling the person who brought up the issue that it is somehow their fault that this unpleasant situation has come about. You can only imagine the ramifications of that insinuation. So, just don’t try to justify any part of what happened. <br />Once you have these pieces in place, whatever resolution you come up with likely to be better received, and therefore, result in a better outcome. </p>
-<!-- /wp:paragraph -->
+By becoming an apologist for the status quo, you are effectively victim-blaming. You are telling the person who brought up the issue that it is somehow their fault that this unpleasant situation has come about. You can only imagine the ramifications of that insinuation. So, just don’t try to justify any part of what happened.
+
+Once you have these pieces in place, whatever resolution you come up with likely to be better received, and therefore, result in a better outcome.


### PR DESCRIPTION
## Batch 2: Photo essays and image-heavy posts

Converts 6 posts from HTML to clean markdown:

- `tsarevets-a-photo-essay` (22 images)
- `troyan-monastery` (16 images, fixed 7 bare `/images/` → `/assets/images/` paths)
- `sevlievo` (26 images)
- `shipka-memorial-church` (9 images)
- `when-should-you-build-for-survival` (5 images)
- `responding-to-concerns-as-a-people-manager` (7 images)

### Changes
- All HTML converted to markdown (figures, figcaptions, paragraphs, headings, lists, links)
- `guid:` and `fplayout:` frontmatter stripped
- Non-breaking spaces replaced
- Bare `/images/` paths corrected to `/assets/images/`
- No content changes — format migration only