### PR TITLE
Garden sync May 2: trim + format 8 notes; fix sync script

### DIFF
--- a/_garden/confabulation-is-plausible.md
+++ b/_garden/confabulation-is-plausible.md
@@ -1,22 +1,21 @@
 ---
 title: "Confabulation Is Plausible"
-garden_type: thought
+garden_type: note
 maturity: budding
 tags: [ai, failure-modes, hallucination]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - suggestible-actor-properties
-  - directive-gap
-  - susceptibility-peaks-at-failure
   - ambient-to-local
+  - directive-gap
+  - suggestible-actor-properties
+  - susceptibility-peaks-at-failure
 excerpt_text: >
-  **AI agent confabulation is not random.** It is plausible-looking wrongness: output constructed from pattern
-  and proximity rather than knowledge. The danger is not that these errors are spectacular; it is that they
-  look correct.
+  AI agent confabulation is not random — it is plausible-looking wrongness constructed from pattern and proximity rather than knowledge.
 ---
 
-AI agent confabulation is not random. It is plausible-looking wrongness: output constructed from pattern and proximity rather than knowledge. It fits the shape of what should be there. This makes confabulation harder to detect than obvious failures, precisely because the output looks correct. The failure mode is not garbage; it is convincing fiction.
+**AI agent confabulation is not random — it is plausible-looking wrongness constructed from pattern and proximity rather than knowledge.** The failure mode is not garbage; it is convincing fiction.
 
-This is the convergent failure mode of the [suggestible actor's](/garden/suggestible-actor-properties/) other three properties. The agent is goal-oriented (so it must produce *something*), locally reasoning (so it draws only from what's nearby), and susceptible to local context (so it pattern-matches from whatever is available). When the [directive gap](/garden/directive-gap/) is wide and local context is insufficient, the agent fills the void with plausible structure: a call to an API that does not exist, a convention that was never established, a security bypass that "should work based on the patterns in this codebase."
+This is the convergent failure mode of the suggestible actor's other three properties. The agent is goal-oriented (so it must produce *something*), locally reasoning (so it draws only from what's nearby), and susceptible to local context (so it pattern-matches from whatever is available). When the directive gap is wide and local context is insufficient, the agent fills the void with plausible structure: a call to an API that does not exist, a convention that was never established, a security bypass that "should work based on the patterns in this codebase."

--- a/_garden/data-pipeline-is-achilles-heel.md
+++ b/_garden/data-pipeline-is-achilles-heel.md
@@ -2,7 +2,6 @@
 title: "Data Pipeline Is Achilles Heel"
 garden_type: note
 maturity: budding
-tags: [governance, bounded-rationality, information-asymmetry, data-quality]
 created: 2026-04-25
 related_posts:
   - /directive-governance-situationship/
@@ -16,4 +15,4 @@ excerpt_text: >
 
 **The data pipeline is directive governance's Achilles heel, not the decision-maker's rationality.**
 
-Claiming directive governance assumes executives are homo economicus is a strawman nobody defends. Directive governance assumes bounded rationality, which is realistic. The real vulnerability: the quality of bounded-rational decisions is only as good as the data available. The pipeline depends on three conditions specific to directive governance: (1) compression at each layer preserves the relevant signal, (2) quantitative proxies correlate with underlying reality, (3) decisions and execution are cleanly separable. All three fail structurally in large tech, not because anyone is incompetent, but because the pipeline degrades below the threshold for adequate decision-making. Executives are satisficing on garbage input.
+Claiming directive governance assumes executives are homo economicus is a strawman nobody defends. Directive governance assumes bounded rationality, which is realistic. The real vulnerability: the quality of bounded-rational decisions is only as good as the data available. The pipeline depends on three conditions specific to directive governance: (1) compression at each layer preserves the relevant signal, (2) quantitative proxies correlate with underlying reality, (3) decisions and execution are cleanly separable. All three fail structurally in large tech — not because anyone is incompetent, but because the pipeline degrades below the threshold for adequate decision-making. Executives are satisficing on garbage input.

--- a/_garden/friction-requires-intent.md
+++ b/_garden/friction-requires-intent.md
@@ -1,20 +1,20 @@
 ---
 title: "Friction Requires Intent"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [software-design, ergonomics, ai, pit-of-success]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
   - ai-agent-category-error
+  - intent-spectrum
   - suggestible-actor-properties
 excerpt_text: >
-  **Ergonomic friction as a design tool only works when the actor has intent and judgment.** Friction is a signal,
-  and signals require an interpreter. The AI agent encounters friction as an obstacle and routes around it.
+  Ergonomic friction as a design tool only works when the actor has intent and judgment.
 ---
 
-Ergonomic friction as a design tool only works when the actor has intent and judgment. Friction is a signal, and signals require an interpreter. The AI agent has no intent to question and no judgment to interpret. It encounters friction as an obstacle and routes around it. The pit of success fails for actors that cannot feel the terrain.
+**Ergonomic friction as a design tool only works when the actor has intent and judgment.** Friction is a signal, and signals require an interpreter. The AI agent has no intent to question and no judgment to interpret. It encounters friction as an obstacle and routes around it. The pit of success fails for actors that cannot feel the terrain.
 
-When a well-intentioned human developer encounters resistance (a borrow checker complaint, a type error, a deprecation warning), they read it as: *I am probably doing something wrong.* The AI agent reads it as: *this approach didn't work, try another.* The friction was designed as a nudge. For the [suggestible actor](/garden/suggestible-actor-properties/), it is just noise between attempts.
+When a well-intentioned human developer encounters resistance (a borrow checker complaint, a type error, a deprecation warning), they read it as: *I am probably doing something wrong.* The AI agent reads it as: *this approach didn't work, try another.* The friction was designed as a nudge. For the suggestible actor, it is just noise between attempts.

--- a/_garden/goal-vs-intent.md
+++ b/_garden/goal-vs-intent.md
@@ -1,20 +1,20 @@
 ---
 title: "Goal vs. Intent"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, definitions, mental-models]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
   - ai-agent-category-error
+  - intent-spectrum
   - suggestible-actor-properties
 excerpt_text: >
-  **Goal and intent are not the same thing.** Intent implies motivation: the actor wants an outcome, understands
-  why it matters, and can evaluate trade-offs against their own values. A goal is just a target.
+  Goal and intent are not the same thing.
 ---
 
-Goal and intent are not the same thing. Intent implies motivation: the actor *wants* an outcome, understands *why* it matters, and can evaluate trade-offs against their own values. A goal is just a target. The AI agent has a goal (externally set) but no intent. It pursues the goal without comprehension of what it is pointed at or why.
+**Goal and intent are not the same thing.** Intent implies motivation: the actor *wants* an outcome, understands *why* it matters, and can evaluate trade-offs against their own values. A goal is just a target. The AI agent has a goal (externally set) but no intent. It pursues the goal without comprehension of what it is pointed at or why.
 
-This distinction matters because the entire [intent spectrum](/garden/intent-spectrum/) is organized around intent, not goals. Both the well-intentioned actor and the malicious actor have intent. They differ in its direction. The AI agent is not between them on the spectrum; it is orthogonal to it. A heat-seeking missile has a goal. It does not have intent.
+This distinction matters because the entire intent spectrum is organized around intent, not goals. Both the well-intentioned actor and the malicious actor have intent. They differ in its direction. The AI agent is not between them on the spectrum; it is orthogonal to it. A heat-seeking missile has a goal. It does not have intent.

--- a/_garden/in-software-execution-is-decision-making.md
+++ b/_garden/in-software-execution-is-decision-making.md
@@ -1,18 +1,18 @@
 ---
-title: "In Software, Execution Is Decision-Making"
+title: "In Software Execution Is Decision Making"
 garden_type: note
 maturity: evergreen
-tags: [governance, software-engineering, directive-governance, separability]
 created: 2026-04-25
 related_posts:
   - /cargo-cult-governance/
 related_notes:
-  - three-assumptions-framework
+  - data-pipeline-is-achilles-heel
   - essential-complexity-makes-software-ungovernable
+  - metrics-measure-maintenance-not-creation
 excerpt_text: >
-  The decision/execution boundary that directive governance depends on does not exist in software. Every act of building code is a design decision, and software decisions compound.
+  The decision/execution boundary that directive governance depends on does not exist in software.
 ---
 
-**The decision/execution boundary that directive governance depends on does not exist in software.** In manufacturing, the design decision was already made, and execution follows a spec. Micro-decisions on the line are local and ephemeral.
+**The decision/execution boundary that directive governance depends on does not exist in software.** In manufacturing, the design decision was already made and execution follows a spec. In software, everything you build is new. If it were not new, you would call the API that already does it. Every act of writing code is a design decision: choosing an abstraction, designing an interface, decomposing a system. No spec can fully predetermine these choices because essential complexity (Brooks) cannot be fully specified.
 
-In software, everything you build is new. Every act of writing code is a design decision: choosing an abstraction, designing an interface, decomposing a system. And software decisions compound. Every abstraction choice constrains every future choice built on top of it. The center cannot centralize what is embedded in the act of writing code.
+Software decisions also compound. Every abstraction choice constrains every future choice built on top of it. A software decision lives on in the codebase and shapes all future work. The center cannot centralize what is embedded in the act of writing code.

--- a/_garden/intent-spectrum.md
+++ b/_garden/intent-spectrum.md
@@ -1,21 +1,20 @@
 ---
 title: "The Intent Spectrum"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [software-design, actor-models, mental-models]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
   - ai-agent-category-error
-  - goal-vs-intent
   - friction-requires-intent
+  - goal-vs-intent
 excerpt_text: >
-  **All software design assumes an actor with intent.** The well-intentioned actor and the malicious actor are
-  archetypes at opposite ends of an intent spectrum. Every design paradigm is a response to where the
-  designer places the actor on that spectrum.
+  All software design assumes an actor with intent.
 ---
 
-All software design assumes an actor with intent. The well-intentioned actor and the malicious actor are archetypes at opposite ends of an intent spectrum. Every design paradigm (the pit of success, the fortress) is a response to where the designer places the actor on that spectrum. The spectrum's organizing axis is intent itself.
+**All software design assumes an actor with intent.** The well-intentioned actor and the malicious actor are archetypes at opposite ends of an intent spectrum. Every design paradigm (the pit of success, the fortress) is a response to where the designer places the actor on that spectrum. The spectrum's organizing axis is intent itself.
 
-This binary held for decades. But it breaks when you introduce an actor that has no intent at all: the AI coding agent. Placing it on the intent spectrum is a [category error](/garden/ai-agent-category-error/). The entire axis is organized around something the agent doesn't have.
+This binary held for decades. But it breaks when you introduce an actor that has no intent at all: the AI coding agent. Placing it on the intent spectrum is a category error. The entire axis is organized around something the agent doesn't have.

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -216,6 +216,16 @@ for pkm_file in "${FILES[@]}"; do
         continue
     fi
 
+    # Preserve existing related_posts before overwriting
+    existing_related_posts=()
+    if [ -f "$garden_file" ]; then
+        while IFS= read -r rp; do
+            [ -z "$rp" ] && continue
+            rp=$(echo "$rp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            existing_related_posts+=("$rp")
+        done < <(get_fm_list "$garden_file" "related_posts")
+    fi
+
     echo "🌱 Converting: $basename → _garden/${slug}.md"
 
     # ── Extract PKM frontmatter ──
@@ -308,7 +318,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     fi
 
-    # Process 'inspired_by' (single value or inline array)
+    # Process 'inspired_by' (single value, inline array, or multi-line list)
     if [ -n "$pkm_inspired_by" ]; then
         if [[ "$pkm_inspired_by" == \[* ]]; then
             while IFS= read -r ref; do
@@ -329,11 +339,33 @@ for pkm_file in "${FILES[@]}"; do
             fi
         fi
     fi
+    # Also check multi-line inspired_by list
+    while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        resolved=$(ref_to_slug "$ref")
+        if [[ "$resolved" == PUBLISHED:* ]]; then
+            related_posts+=("${resolved#PUBLISHED:}")
+        else
+            related_notes+=("$resolved")
+        fi
+    done < <(get_fm_list "$pkm_file" "inspired_by")
 
     # Deduplicate related_notes
     if [ ${#related_notes[@]} -gt 0 ]; then
         mapfile -t related_notes < <(printf '%s\n' "${related_notes[@]}" | sort -u)
     fi
+
+    # Validate related_notes: only keep slugs that exist in _garden/
+    validated_notes=()
+    for rn in "${related_notes[@]}"; do
+        if [ -f "$GARDEN_DIR/${rn}.md" ]; then
+            validated_notes+=("$rn")
+        else
+            echo "   ⚠  Dropping related_note '$rn' (no garden file exists)"
+        fi
+    done
+    related_notes=("${validated_notes[@]+"${validated_notes[@]}"}")
 
     # ── Extract and process body ──
 
@@ -343,6 +375,28 @@ for pkm_file in "${FILES[@]}"; do
 
     # Extract excerpt (first sentence of body, stripped of markdown)
     excerpt=$(first_sentence "$body")
+
+    # ── Compute related_posts (preserve existing + merge newly derived) ──
+
+    all_related_posts=()
+    for rp in "${existing_related_posts[@]+"${existing_related_posts[@]}"}"; do
+        [ -n "$rp" ] && all_related_posts+=("$rp")
+    done
+    for rp in "${related_posts[@]+"${related_posts[@]}"}"; do
+        [ -n "$rp" ] && all_related_posts+=("$rp")
+    done
+    # Deduplicate
+    if [ ${#all_related_posts[@]} -gt 0 ]; then
+        mapfile -t all_related_posts < <(printf '%s\n' "${all_related_posts[@]}" | sort -u)
+    fi
+
+    # ── Gate: garden notes require at least one linked post ──
+
+    if [ ${#all_related_posts[@]} -eq 0 ]; then
+        echo "⏭  Skipping $slug (no related_posts — garden notes require at least one linked post)"
+        skipped_count=$((skipped_count + 1))
+        continue
+    fi
 
     # ── Write garden file ──
 
@@ -358,8 +412,11 @@ for pkm_file in "${FILES[@]}"; do
             echo "created: $created"
         fi
 
-        # Related posts (empty by default — user fills in permalinks)
-        echo "related_posts: []"
+        # Related posts
+        echo "related_posts:"
+        for rp in "${all_related_posts[@]}"; do
+            echo "  - $rp"
+        done
 
         # Related notes
         if [ ${#related_notes[@]} -gt 0 ]; then


### PR DESCRIPTION
## Garden sync — May 2, 2026

### Notes updated (8 files)
- **Trimmed (5):** security-is-ambient-knowledge, subsidiarity-is-not-hayek, data-pipeline-is-achilles-heel, confabulation-is-plausible, in-software-execution-is-decision-making
- **Bold lead added (3):** friction-requires-intent, goal-vs-intent, intent-spectrum

### Script fixes (`scripts/pkm-to-garden.sh`)
1. **Preserve `related_posts` on `--force`** — reads existing garden file before overwriting, merges preserved values with newly derived ones
2. **Validate `related_notes`** — drops slugs where `_garden/<slug>.md` doesn't exist (warns instead of creating broken links)
3. **Handle `inspired_by` multi-line lists** — `get_fm_list` fallback alongside single-value and inline-array parsing
4. **Gate on `related_posts`** — refuses to create a garden note unless it has at least one linked post (garden is a concept index for published work, not a public PKM)

### Removed from earlier version
6 orphan notes (no `related_posts`) were removed. They'll be added when a post referencing them ships:
- oss-communities-as-subsidiarity
- ai-mercenary-contributions-erode-subsidiarity
- contributor-poker-review-as-investment
- hollow-commons-schism-pattern
- security-is-ambient-knowledge
- subsidiarity-is-not-hayek