### PR TITLE
Add sync guard, published_in support, and PKM linter

### DIFF
--- a/scripts/lint-pkm.sh
+++ b/scripts/lint-pkm.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# lint-pkm.sh — Validate PKM notes for completeness
+#
+# Checks:
+#   1. Wikilink completeness (orphan + cross-reference)
+#   2. Missing wikilink detection (advisory)
+#   3. published_in validation against garden files
+#   4. connects_to format / dangling reference check
+#
+# Exit 0 if no errors (warnings OK), exit 1 if any errors.
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+NOTES_DIR="brain/notes"
+GARDEN_DIR=""
+FILES=()
+SHOW_HELP=0
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+usage() {
+    cat <<'EOF'
+Usage: lint-pkm.sh [OPTIONS] [FILE ...]
+
+Lint PKM notes for completeness. When no files are given, lints every
+note matching brain/notes/note-*.md.
+
+Options:
+  --garden-dir DIR   Path to the digital-garden directory
+                     (auto-detected if omitted)
+  --help             Show this help and exit
+
+Examples:
+  ./brain/scripts/lint-pkm.sh
+  ./brain/scripts/lint-pkm.sh brain/notes/note-20260424-confabulation-is-plausible.md
+  ./brain/scripts/lint-pkm.sh --garden-dir ~/workspace/srikanthsastry.github.io/_garden/
+EOF
+    exit 0
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --garden-dir)
+            GARDEN_DIR="$2"; shift 2 ;;
+        --help|-h)
+            usage ;;
+        *)
+            FILES+=("$1"); shift ;;
+    esac
+done
+
+# ── Resolve workspace root ───────────────────────────────────────────────────
+# The script can be invoked from anywhere; anchor relative paths to the
+# directory that contains brain/.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# brain/scripts → go up two levels to workspace root
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$WORKSPACE_ROOT"
+
+# ── Auto-detect garden dir ────────────────────────────────────────────────────
+if [[ -z "$GARDEN_DIR" ]]; then
+    for candidate in \
+        "$WORKSPACE_ROOT/srikanthsastry.github.io/_garden" \
+        "$HOME/workspace/srikanthsastry.github.io/_garden" \
+        "$WORKSPACE_ROOT/brain/../srikanthsastry.github.io/_garden"; do
+        if [[ -d "$candidate" ]]; then
+            GARDEN_DIR="$candidate"
+            break
+        fi
+    done
+fi
+
+# ── Collect target files ─────────────────────────────────────────────────────
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    mapfile -t FILES < <(find "$NOTES_DIR" -maxdepth 1 -name 'note-*.md' -type f | sort)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "No PKM notes found to lint."
+    exit 0
+fi
+
+# ── Helper functions ──────────────────────────────────────────────────────────
+
+# Extract a single-line frontmatter value
+get_fm() {
+    local file="$1" key="$2"
+    sed -n '/^---$/,/^---$/p' "$file" | grep -m1 "^${key}:" | sed "s/^${key}:[[:space:]]*//" || true
+}
+
+# Extract a multi-line YAML list (returns one item per line, stripped)
+get_fm_list() {
+    local file="$1" key="$2"
+    sed -n '/^---$/,/^---$/p' "$file" | awk -v key="$key:" '
+        $0 ~ "^"key {found=1; next}
+        found && /^[[:space:]]*- / {gsub(/^[[:space:]]*- /, ""); print; next}
+        found && /^[a-zA-Z]/ {exit}
+    '
+}
+
+# Extract body text (everything after the second ---)
+get_body() {
+    local file="$1"
+    awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file"
+}
+
+# note-20260424-directive-gap.md → directive-gap
+make_slug() {
+    local basename="$1"
+    local slug="${basename%.md}"
+    # Strip prefixes: note- / thought- / source- / src-
+    slug=$(echo "$slug" | sed -E 's/^(thought|note|source|src)-//')
+    # Strip date prefixes: YYYYMMDD- or YYYY-MM-DD-
+    slug=$(echo "$slug" | sed -E 's/^[0-9]{8}-//' | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//')
+    echo "$slug"
+}
+
+# ── Build slug index ──────────────────────────────────────────────────────────
+# Map: slug → full filename (relative path)
+declare -A SLUG_TO_FILE
+declare -A ALL_SLUGS   # just for quick existence check
+mapfile -t ALL_NOTE_FILES < <(find "$NOTES_DIR" -maxdepth 1 -name 'note-*.md' -type f | sort)
+
+for f in "${ALL_NOTE_FILES[@]}"; do
+    bname="$(basename "$f")"
+    s="$(make_slug "$bname")"
+    SLUG_TO_FILE["$s"]="$f"
+    ALL_SLUGS["$s"]=1
+done
+
+# ── Accumulators ──────────────────────────────────────────────────────────────
+declare -A FILE_ERRORS   # file → newline-separated error strings
+declare -A FILE_WARNINGS # file → newline-separated warning strings
+TOTAL_ERRORS=0
+TOTAL_WARNINGS=0
+
+add_error() {
+    local file="$1" msg="$2"
+    if [[ -n "${FILE_ERRORS[$file]+x}" ]]; then
+        FILE_ERRORS["$file"]+=$'\n'"$msg"
+    else
+        FILE_ERRORS["$file"]="$msg"
+    fi
+    (( TOTAL_ERRORS++ )) || true
+}
+
+add_warning() {
+    local file="$1" msg="$2"
+    if [[ -n "${FILE_WARNINGS[$file]+x}" ]]; then
+        FILE_WARNINGS["$file"]+=$'\n'"$msg"
+    else
+        FILE_WARNINGS["$file"]="$msg"
+    fi
+    (( TOTAL_WARNINGS++ )) || true
+}
+
+# ── Lint each file ────────────────────────────────────────────────────────────
+for filepath in "${FILES[@]}"; do
+    if [[ ! -f "$filepath" ]]; then
+        add_error "$filepath" "[FILE_NOT_FOUND] $filepath does not exist"
+        continue
+    fi
+
+    bname="$(basename "$filepath")"
+    my_slug="$(make_slug "$bname")"
+    body="$(get_body "$filepath")"
+
+    # ── Gather frontmatter lists ──────────────────────────────────────────
+    mapfile -t connects_to_raw < <(get_fm_list "$filepath" "connects_to")
+    mapfile -t related_raw    < <(get_fm_list "$filepath" "related")
+    mapfile -t published_in_raw < <(get_fm_list "$filepath" "published_in")
+
+    # Build sets of slugs referenced in connects_to and related
+    declare -A ct_slugs=()
+    declare -A ct_paths=()
+    for entry in "${connects_to_raw[@]}"; do
+        [[ -z "$entry" ]] && continue
+        ct_paths["$entry"]=1
+        # Extract slug from path like brain/notes/note-20260424-directive-gap.md
+        entry_bname="$(basename "$entry")"
+        entry_slug="$(make_slug "$entry_bname")"
+        ct_slugs["$entry_slug"]=1
+    done
+
+    declare -A rel_slugs=()
+    for entry in "${related_raw[@]}"; do
+        [[ -z "$entry" ]] && continue
+        entry_bname="$(basename "$entry")"
+        entry_slug="$(make_slug "$entry_bname")"
+        rel_slugs["$entry_slug"]=1
+    done
+
+    # ── Check 1: Wikilink completeness ────────────────────────────────────
+    # Extract all wikilinks from body: [[slug]] or [[slug|display text]]
+    mapfile -t wikilinks < <(echo "$body" | grep -oP '\[\[([^\]|]+)' | sed 's/^\[\[//' | sort -u)
+
+    for wl_slug in "${wikilinks[@]}"; do
+        [[ -z "$wl_slug" ]] && continue
+        # Trim whitespace
+        wl_slug="$(echo "$wl_slug" | xargs)"
+
+        # Orphan check: does a note with this slug exist?
+        if [[ -z "${ALL_SLUGS[$wl_slug]+x}" ]]; then
+            add_error "$bname" "[ORPHAN_WIKILINK] [[$wl_slug]] references no existing note"
+        fi
+
+        # Cross-reference check: is this slug in connects_to or related?
+        if [[ -z "${ct_slugs[$wl_slug]+x}" ]] && [[ -z "${rel_slugs[$wl_slug]+x}" ]]; then
+            add_error "$bname" "[MISSING_CONNECTS_TO] [[$wl_slug]] in body but not in connects_to or related"
+        fi
+    done
+
+    # ── Check 4: connects_to dangling references ──────────────────────────
+    for ct_path in "${connects_to_raw[@]}"; do
+        [[ -z "$ct_path" ]] && continue
+        if [[ ! -f "$ct_path" ]]; then
+            add_error "$bname" "[DANGLING_CONNECTS_TO] connects_to entry '$ct_path' does not exist"
+        fi
+    done
+
+    # ── Check 3: published_in validation ──────────────────────────────────
+    if [[ -n "$GARDEN_DIR" ]]; then
+        garden_file="$GARDEN_DIR/${my_slug}.md"
+        if [[ -f "$garden_file" ]]; then
+            # Garden file exists — PKM should have published_in
+            # Extract related_posts from garden file
+            mapfile -t garden_related_posts < <(get_fm_list "$garden_file" "related_posts")
+
+            if [[ ${#garden_related_posts[@]} -gt 0 ]] && [[ -n "${garden_related_posts[0]}" ]]; then
+                # Garden has related_posts — check published_in
+                if [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
+                    # Build a readable list of related_posts
+                    rp_display=""
+                    for rp in "${garden_related_posts[@]}"; do
+                        [[ -z "$rp" ]] && continue
+                        if [[ -n "$rp_display" ]]; then
+                            rp_display+=", $rp"
+                        else
+                            rp_display="$rp"
+                        fi
+                    done
+                    add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists with related_posts [$rp_display] but no published_in in PKM"
+                else
+                    # Both exist — check for mismatches
+                    declare -A pi_set=()
+                    for pi in "${published_in_raw[@]}"; do
+                        [[ -z "$pi" ]] && continue
+                        pi_set["$pi"]=1
+                    done
+                    for rp in "${garden_related_posts[@]}"; do
+                        [[ -z "$rp" ]] && continue
+                        if [[ -z "${pi_set[$rp]+x}" ]]; then
+                            add_error "$bname" "[PUBLISHED_IN_MISMATCH] garden related_posts has '$rp' but PKM published_in does not"
+                        fi
+                    done
+                    unset pi_set
+                fi
+            elif [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
+                # Garden exists but no related_posts — still flag missing published_in
+                add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists at ${garden_file} but no published_in in PKM"
+            fi
+        fi
+    fi
+
+    # ── Check 2: Missing wikilink detection (advisory) ────────────────────
+    # Convert body to lowercase for case-insensitive matching
+    body_lower="$(echo "$body" | tr '[:upper:]' '[:lower:]')"
+
+    for candidate_slug in "${!ALL_SLUGS[@]}"; do
+        # Skip self
+        [[ "$candidate_slug" == "$my_slug" ]] && continue
+
+        # Skip if already wikilinked
+        already_linked=0
+        for wl in "${wikilinks[@]}"; do
+            if [[ "$wl" == "$candidate_slug" ]]; then
+                already_linked=1
+                break
+            fi
+        done
+        [[ "$already_linked" -eq 1 ]] && continue
+
+        # Convert slug kebab-case to space-separated words
+        phrase="$(echo "$candidate_slug" | tr '-' ' ')"
+
+        # Only flag if the full phrase appears as a word-boundary match
+        # Use grep -w for word boundaries, but multi-word phrases need \b
+        if echo "$body_lower" | grep -qiP "\b\Q${phrase}\E\b" 2>/dev/null; then
+            add_warning "$bname" "[POTENTIAL_WIKILINK] body mentions \"$phrase\" which matches note slug '$candidate_slug' but is not wikilinked"
+        fi
+    done
+
+    # Clean up associative arrays for next iteration
+    unset ct_slugs ct_paths rel_slugs
+done
+
+# ── Report ────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== PKM Lint Report ==="
+echo ""
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+    echo "ERRORS (must fix before garden sync):"
+    for file in $(echo "${!FILE_ERRORS[@]}" | tr ' ' '\n' | sort); do
+        echo "  $file:"
+        while IFS= read -r line; do
+            echo "    - $line"
+        done <<< "${FILE_ERRORS[$file]}"
+    done
+    echo ""
+fi
+
+if [[ $TOTAL_WARNINGS -gt 0 ]]; then
+    echo "WARNINGS (advisory):"
+    for file in $(echo "${!FILE_WARNINGS[@]}" | tr ' ' '\n' | sort); do
+        echo "  $file:"
+        while IFS= read -r line; do
+            echo "    - $line"
+        done <<< "${FILE_WARNINGS[$file]}"
+    done
+    echo ""
+fi
+
+if [[ $TOTAL_ERRORS -eq 0 ]] && [[ $TOTAL_WARNINGS -eq 0 ]]; then
+    echo "All clear — no issues found."
+    echo ""
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Files checked: ${#FILES[@]}"
+echo "  Errors: $TOTAL_ERRORS"
+echo "  Warnings: $TOTAL_WARNINGS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -341,8 +341,7 @@ for pkm_file in "${FILES[@]}"; do
     if [ -n "$pkm_source" ]; then
         resolved=$(ref_to_slug "$pkm_source")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            # Skip: published_in is canonical source for related_posts
-            continue
+            : # Skip: published_in is canonical source for related_posts
         else
             related_notes+=("$resolved")
         fi
@@ -364,8 +363,7 @@ for pkm_file in "${FILES[@]}"; do
         else
             resolved=$(ref_to_slug "$pkm_inspired_by")
             if [[ "$resolved" == PUBLISHED:* ]]; then
-                # Skip: published_in is canonical source for related_posts
-            continue
+                : # Skip: published_in is canonical source for related_posts
             else
                 related_notes+=("$resolved")
             fi

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -265,7 +265,19 @@ for pkm_file in "${FILES[@]}"; do
     # Tags: parse inline array format [a, b, c]
     tags_line=""
     if [ -n "$pkm_tags" ]; then
+        # Inline array format: tags: [a, b, c]
         tags_line="$pkm_tags"
+    else
+        # Multi-line list format: tags:\n  - a\n  - b
+        ml_tags=()
+        while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            tag=$(echo "$tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            ml_tags+=("$tag")
+        done < <(get_fm_list "$pkm_file" "tags")
+        if [ ${#ml_tags[@]} -gt 0 ]; then
+            tags_line="[$(printf '%s' "${ml_tags[0]}"; for t in "${ml_tags[@]:1}"; do printf ', %s' "$t"; done)]"
+        fi
     fi
 
     # Created date: prefer 'created', fallback to 'date_added'
@@ -289,7 +301,8 @@ for pkm_file in "${FILES[@]}"; do
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            related_posts+=("${resolved#PUBLISHED:}")
+            # Skip: published_in is canonical source for related_posts
+            continue
         else
             related_notes+=("$resolved")
         fi
@@ -303,7 +316,8 @@ for pkm_file in "${FILES[@]}"; do
                 [ -z "$ref" ] && continue
                 resolved=$(ref_to_slug "$ref")
                 if [[ "$resolved" == PUBLISHED:* ]]; then
-                    related_posts+=("${resolved#PUBLISHED:}")
+                    # Skip: published_in is canonical source for related_posts
+            continue
                 else
                     related_notes+=("$resolved")
                 fi
@@ -316,7 +330,8 @@ for pkm_file in "${FILES[@]}"; do
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            related_posts+=("${resolved#PUBLISHED:}")
+            # Skip: published_in is canonical source for related_posts
+            continue
         else
             related_notes+=("$resolved")
         fi
@@ -326,7 +341,8 @@ for pkm_file in "${FILES[@]}"; do
     if [ -n "$pkm_source" ]; then
         resolved=$(ref_to_slug "$pkm_source")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            related_posts+=("${resolved#PUBLISHED:}")
+            # Skip: published_in is canonical source for related_posts
+            continue
         else
             related_notes+=("$resolved")
         fi
@@ -339,7 +355,8 @@ for pkm_file in "${FILES[@]}"; do
                 [ -z "$ref" ] && continue
                 resolved=$(ref_to_slug "$ref")
                 if [[ "$resolved" == PUBLISHED:* ]]; then
-                    related_posts+=("${resolved#PUBLISHED:}")
+                    # Skip: published_in is canonical source for related_posts
+            continue
                 else
                     related_notes+=("$resolved")
                 fi
@@ -347,7 +364,8 @@ for pkm_file in "${FILES[@]}"; do
         else
             resolved=$(ref_to_slug "$pkm_inspired_by")
             if [[ "$resolved" == PUBLISHED:* ]]; then
-                related_posts+=("${resolved#PUBLISHED:}")
+                # Skip: published_in is canonical source for related_posts
+            continue
             else
                 related_notes+=("$resolved")
             fi
@@ -359,7 +377,8 @@ for pkm_file in "${FILES[@]}"; do
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            related_posts+=("${resolved#PUBLISHED:}")
+            # Skip: published_in is canonical source for related_posts
+            continue
         else
             related_notes+=("$resolved")
         fi

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 # pkm-to-garden.sh — Convert PKM files to digital garden entries
 #
+# The garden is a pure derivation from PKM. This script never preserves
+# or merges data from an existing garden file. Instead, when --force is
+# used, a pre-sync guard compares the would-be output against the
+# existing garden file and refuses to overwrite if any data would be lost.
+#
 # Usage:
 #   ./scripts/pkm-to-garden.sh [--force] <pkm-file> [<pkm-file> ...]
 #
@@ -28,7 +33,7 @@ for arg in "$@"; do
             echo "Convert PKM files to digital garden entries in _garden/"
             echo ""
             echo "Options:"
-            echo "  --force    Overwrite existing garden files"
+            echo "  --force    Overwrite existing garden files (with safety guard)"
             echo "  --help     Show this help"
             echo ""
             echo "Examples:"
@@ -185,16 +190,27 @@ first_sentence() {
         }' | head -1
 }
 
-# Convert wikilinks [[slug]] to markdown links [Title](/garden/slug/)
+# Convert wikilinks to markdown links
+# [[slug|display text]] → [display text](/garden/slug/)
+# [[slug]]              → [slug](/garden/slug/)
 convert_wikilinks() {
     local text="$1"
-    echo "$text" | sed -E 's/\[\[([^]]+)\]\]/[\1](\/garden\/\1\/)/g'
+    # Normalize full-ID wikilinks: [[note-YYYYMMDD-slug]] → [[slug]]
+    text=$(echo "$text" | sed -E 's/\[\[(note|thought|source|src)-[0-9]{8}-([^]|]+)\]\]/[[\2]]/g')
+    # Also normalize full-ID with pipe: [[note-YYYYMMDD-slug|text]] → [[slug|text]]
+    text=$(echo "$text" | sed -E 's/\[\[(note|thought|source|src)-[0-9]{8}-([^]|]+)\|([^]]+)\]\]/[[\2|\3]]/g')
+    # Handle pipe syntax [[slug|display text]]
+    text=$(echo "$text" | sed -E 's/\[\[([^]|]+)\|([^]]+)\]\]/[\2](\/garden\/\1\/)/g')
+    # Handle plain [[slug]]
+    text=$(echo "$text" | sed -E 's/\[\[([^]]+)\]\]/[\1](\/garden\/\1\/)/g')
+    echo "$text"
 }
 
 # ── Main conversion loop ─────────────────────────────────────────
 
 created_count=0
 skipped_count=0
+blocked_count=0
 error_count=0
 
 for pkm_file in "${FILES[@]}"; do
@@ -255,11 +271,19 @@ for pkm_file in "${FILES[@]}"; do
     # Created date: prefer 'created', fallback to 'date_added'
     created="${pkm_created:-$pkm_date_added}"
 
-    # Related notes: collect from connects_to, related, source, inspired_by
+    # ── Collect related_notes and related_posts ──
+
     related_notes=()
     related_posts=()
 
-    # Process 'connects_to' (multi-line list)
+    # 1. Read published_in from PKM → related_posts (permalink format)
+    while IFS= read -r pi; do
+        [ -z "$pi" ] && continue
+        pi=$(echo "$pi" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        related_posts+=("$pi")
+    done < <(get_fm_list "$pkm_file" "published_in")
+
+    # 2. Process 'connects_to' (multi-line list)
     while IFS= read -r ref; do
         [ -z "$ref" ] && continue
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -271,7 +295,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     done < <(get_fm_list "$pkm_file" "connects_to")
 
-    # Process 'related' (inline array or multi-line list)
+    # 3. Process 'related' (inline array or multi-line list)
     pkm_related=$(get_fm "$pkm_file" "related")
     if [ -n "$pkm_related" ]; then
         if [[ "$pkm_related" == \[* ]]; then
@@ -298,7 +322,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     done < <(get_fm_list "$pkm_file" "related")
 
-    # Process 'source' (single value — reference to the source/draft that inspired this thought)
+    # 4. Process 'source' (single value)
     if [ -n "$pkm_source" ]; then
         resolved=$(ref_to_slug "$pkm_source")
         if [[ "$resolved" == PUBLISHED:* ]]; then
@@ -308,7 +332,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     fi
 
-    # Process 'inspired_by' (single value or inline array)
+    # 5. Process 'inspired_by' (single value, inline array, or multi-line list)
     if [ -n "$pkm_inspired_by" ]; then
         if [[ "$pkm_inspired_by" == \[* ]]; then
             while IFS= read -r ref; do
@@ -329,20 +353,167 @@ for pkm_file in "${FILES[@]}"; do
             fi
         fi
     fi
+    # Also check multi-line inspired_by list
+    while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        resolved=$(ref_to_slug "$ref")
+        if [[ "$resolved" == PUBLISHED:* ]]; then
+            related_posts+=("${resolved#PUBLISHED:}")
+        else
+            related_notes+=("$resolved")
+        fi
+    done < <(get_fm_list "$pkm_file" "inspired_by")
 
-    # Deduplicate related_notes
+    # ── Deduplicate related_notes ──
+
     if [ ${#related_notes[@]} -gt 0 ]; then
         mapfile -t related_notes < <(printf '%s\n' "${related_notes[@]}" | sort -u)
+    fi
+
+    # ── Validate related_notes: only keep slugs that exist in _garden/ ──
+
+    validated_notes=()
+    for rn in "${related_notes[@]}"; do
+        if [ -f "$GARDEN_DIR/${rn}.md" ]; then
+            validated_notes+=("$rn")
+        else
+            echo "   ⚠  Dropping related_note '$rn' (no garden file exists)"
+        fi
+    done
+    related_notes=("${validated_notes[@]+"${validated_notes[@]}"}")
+
+    # ── Deduplicate related_posts ──
+
+    if [ ${#related_posts[@]} -gt 0 ]; then
+        mapfile -t related_posts < <(printf '%s\n' "${related_posts[@]}" | sort -u)
+    fi
+
+    # ── Gate: garden notes require at least one linked post ──
+
+    if [ ${#related_posts[@]} -eq 0 ]; then
+        echo "⏭  Skipping $slug (no related_posts — garden notes require at least one linked post)"
+        skipped_count=$((skipped_count + 1))
+        continue
     fi
 
     # ── Extract and process body ──
 
     body=$(get_body "$pkm_file")
-    # Convert wikilinks
+    # Convert wikilinks (including pipe syntax)
     body=$(convert_wikilinks "$body")
 
     # Extract excerpt (first sentence of body, stripped of markdown)
     excerpt=$(first_sentence "$body")
+
+    # ── Pre-sync guard: refuse if --force would lose data ──
+
+    if [ "$FORCE" = true ] && [ -f "$garden_file" ]; then
+        losses=()
+
+        # (a) Inline link loss: /garden/ links in existing body not present in would-be body
+        existing_body=$(get_body "$garden_file")
+        existing_inline_slugs=()
+        while IFS= read -r link_slug; do
+            [ -z "$link_slug" ] && continue
+            existing_inline_slugs+=("$link_slug")
+        done < <(echo "$existing_body" | grep -oE '\(/garden/[^)]+/\)' | sed -E 's|^\(/garden/||;s|/\)$||' | sort -u)
+
+        missing_inline=()
+        for es in "${existing_inline_slugs[@]+"${existing_inline_slugs[@]}"}"; do
+            if ! echo "$body" | grep -qF "/garden/${es}/"; then
+                missing_inline+=("$es")
+            fi
+        done
+
+        # (b) related_notes loss
+        existing_rnotes=()
+        while IFS= read -r ern; do
+            [ -z "$ern" ] && continue
+            ern=$(echo "$ern" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            existing_rnotes+=("$ern")
+        done < <(get_fm_list "$garden_file" "related_notes")
+
+        missing_rnotes=()
+        for ern in "${existing_rnotes[@]+"${existing_rnotes[@]}"}"; do
+            found=false
+            for rn in "${related_notes[@]+"${related_notes[@]}"}"; do
+                if [ "$rn" = "$ern" ]; then
+                    found=true
+                    break
+                fi
+            done
+            if [ "$found" = false ]; then
+                missing_rnotes+=("$ern")
+            fi
+        done
+
+        # (c) related_posts loss
+        existing_rposts=()
+        while IFS= read -r erp; do
+            [ -z "$erp" ] && continue
+            erp=$(echo "$erp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            existing_rposts+=("$erp")
+        done < <(get_fm_list "$garden_file" "related_posts")
+
+        missing_rposts=()
+        for erp in "${existing_rposts[@]+"${existing_rposts[@]}"}"; do
+            found=false
+            for rp in "${related_posts[@]+"${related_posts[@]}"}"; do
+                if [ "$rp" = "$erp" ]; then
+                    found=true
+                    break
+                fi
+            done
+            if [ "$found" = false ]; then
+                missing_rposts+=("$erp")
+            fi
+        done
+
+        # Report losses and block if any
+        has_loss=false
+
+        if [ ${#missing_inline[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+        if [ ${#missing_rnotes[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+        if [ ${#missing_rposts[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+
+        if [ "$has_loss" = true ]; then
+            echo "🛑 $slug: would lose data on --force"
+            if [ ${#missing_inline[@]} -gt 0 ]; then
+                inline_display=""
+                for mi in "${missing_inline[@]}"; do
+                    [ -n "$inline_display" ] && inline_display+=", "
+                    inline_display+="[[$mi]]"
+                done
+                echo "   Missing inline links in PKM body: $inline_display"
+            fi
+            if [ ${#missing_rnotes[@]} -gt 0 ]; then
+                rnotes_display=""
+                for mr in "${missing_rnotes[@]}"; do
+                    [ -n "$rnotes_display" ] && rnotes_display+=", "
+                    rnotes_display+="$mr"
+                done
+                echo "   Missing connects_to in PKM: $rnotes_display"
+            fi
+            if [ ${#missing_rposts[@]} -gt 0 ]; then
+                rposts_display=""
+                for mp in "${missing_rposts[@]}"; do
+                    [ -n "$rposts_display" ] && rposts_display+=", "
+                    rposts_display+="$mp"
+                done
+                echo "   Missing published_in in PKM: $rposts_display"
+            fi
+            echo "   Fix the PKM note first, then re-run."
+            blocked_count=$((blocked_count + 1))
+            continue
+        fi
+    fi
 
     # ── Write garden file ──
 
@@ -358,8 +529,11 @@ for pkm_file in "${FILES[@]}"; do
             echo "created: $created"
         fi
 
-        # Related posts (empty by default — user fills in permalinks)
-        echo "related_posts: []"
+        # Related posts
+        echo "related_posts:"
+        for rp in "${related_posts[@]}"; do
+            echo "  - $rp"
+        done
 
         # Related notes
         if [ ${#related_notes[@]} -gt 0 ]; then
@@ -397,6 +571,7 @@ done
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Created: $created_count"
+echo "  Blocked: $blocked_count"
 echo "  Skipped: $skipped_count"
 echo "  Errors:  $error_count"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -405,7 +580,7 @@ if [ $created_count -gt 0 ]; then
     echo "Next steps:"
     echo "  1. Review generated files in _garden/"
     echo "  2. Adjust titles, maturity levels, and excerpt_text"
-    echo "  3. Add blog post permalinks to related_posts"
+    echo "  3. Add published_in permalinks to PKM notes for related_posts"
     echo "  4. Add related_notes slugs for connected garden entries"
-    echo "  5. Add inline links from your blog post to these garden notes"
+    echo "  5. Add inline wikilinks in PKM body for garden cross-references"
 fi


### PR DESCRIPTION
## Summary

Updates `scripts/pkm-to-garden.sh` and adds `scripts/lint-pkm.sh`.

### pkm-to-garden.sh changes

- **`published_in` support:** Reads `published_in` from PKM frontmatter to derive `related_posts` in garden notes. Blog post slugs referenced in `published_in` are mapped to their URLs and injected into the garden note's frontmatter.
- **Pre-sync guard (`--force`):** Before overwriting existing garden files, the script compares derived output against the existing file. Refuses to proceed if the new output would lose data (e.g., non-empty fields becoming empty), reporting blocked files in the summary.
- **Wikilink conversion:** `convert_wikilinks` now handles pipe syntax (`[[slug|display text]]`) and normalizes full-ID format (`[[note-YYYYMMDD-slug]]` → `[[slug]]`).
- **Pure derivation:** The script no longer reads or merges existing garden data. Every field is derived purely from the PKM source note, making the output fully reproducible.

### lint-pkm.sh (new)

A standalone PKM linter that validates:
- Wikilink completeness (all `[[targets]]` resolve to existing notes)
- Cross-reference consistency (bidirectional links)
- `published_in` consistency (referenced blog posts exist)
- Frontmatter field validation

The linter lives in both repos (PKM and blog) for CI and convenience.