### PR TITLE
Garden: full re-derive from PKM (77 notes)

### DIFF
--- a/_garden/ai-agent-category-error.md
+++ b/_garden/ai-agent-category-error.md
@@ -1,19 +1,19 @@
 ---
 title: "The AI Agent Category Error"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, software-design, actor-models, category-error]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
-  - goal-vs-intent
-  - suggestible-actor-properties
   - friction-requires-intent
+  - goal-vs-intent
+  - intent-spectrum
+  - suggestible-actor-properties
 excerpt_text: >
-  Placing the AI coding agent on the intent spectrum is a category error. The spectrum assumes the actor
-  has intent. The AI agent has none. It is orthogonal to the entire axis.
+  Placing the AI coding agent on the intent spectrum is a category error.
 ---
 
 **Placing the AI coding agent on the [intent spectrum](/garden/intent-spectrum/) is a category error.** The spectrum assumes the actor has intent. The AI agent has none. It has an externally set objective, no motivation, and no values. It is orthogonal to the intent axis, not somewhere in the middle of it.

--- a/_garden/align-alerts-to-sev-criteria.md
+++ b/_garden/align-alerts-to-sev-criteria.md
@@ -6,6 +6,7 @@ tags: [operations, alerting, monitoring, SLOs, on-call]
 created: 2026-04-27
 related_posts:
   - /sync-your-alerts-to-your-sev-criteria/
+  - let-sleeping-engineers-lie-why-your-alerts-should-match-your-sevs
 related_notes: []
 excerpt_text: >
   Alerts should fire at or near the threshold where an SLO breach would occur, not well before.

--- a/_garden/ambient-to-local.md
+++ b/_garden/ambient-to-local.md
@@ -1,20 +1,20 @@
 ---
 title: "Convert Ambient Knowledge into Local Context"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, software-design, prescriptions]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
+  - confabulation-is-plausible
   - directive-gap
+  - friction-requires-intent
   - suggestible-actor-properties
   - susceptibility-peaks-at-failure
-  - friction-requires-intent
-  - confabulation-is-plausible
 excerpt_text: >
   The core design principle for the suggestible actor: convert ambient knowledge into local context.
-  Human developers carry implicit knowledge the AI agent cannot access. Make it explicit and local.
 ---
 
 **The core design principle for the suggestible actor: convert ambient knowledge into local context.** Human developers carry implicit knowledge (org norms, conventions, institutional history) that the AI agent cannot access. Making that knowledge explicit and local is how you steer an actor that has no judgment.

--- a/_garden/backward-compatibility-for-leaky-abstractions.md
+++ b/_garden/backward-compatibility-for-leaky-abstractions.md
@@ -6,9 +6,10 @@ tags: [software-engineering, backward-compatibility, leaky-abstractions, defensi
 created: 2026-04-27
 related_posts:
   - /backward-compatibility-where-you-dont-expect/
+  - when-backward-compatibility-can-rescue-leaky-abstraction
 related_notes: []
 excerpt_text: >
-  When a framework leaks implementation details, changing a function signature can break assumptions about old vs. new code.
+  When a framework leaks implementation details (like serializing arguments at schedule time but loading code from HEAD at execution time), changing a function signature breaks the assumption that old code calls old signatures.
 ---
 
 **When a framework leaks implementation details (like serializing arguments at schedule time but loading code from HEAD at execution time), changing a function signature breaks the assumption that old code calls old signatures.** The defensive fix is a three-step backward-compatible migration: add `**kwargs` and defaults so old payloads don't crash, change the signature while branching logic based on which params are present, then delete the old logic once all old payloads have drained.

--- a/_garden/check-if-concern-is-systemic.md
+++ b/_garden/check-if-concern-is-systemic.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication]
 created: 2026-04-27
 related_posts:
   - /responding-to-concerns-as-a-people-manager/
+  - responding-to-concerns-as-a-people-manager
 related_notes:
   - concern-response-framework
 excerpt_text: >

--- a/_garden/command-control-misnomer.md
+++ b/_garden/command-control-misnomer.md
@@ -2,7 +2,6 @@
 title: "Command Control Misnomer"
 garden_type: note
 maturity: evergreen
-tags: [governance, directive-governance, terminology]
 created: 2026-04-27
 related_posts:
   - /cargo-cult-governance/

--- a/_garden/concern-response-framework.md
+++ b/_garden/concern-response-framework.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication]
 created: 2026-04-27
 related_posts:
   - /responding-to-concerns-as-a-people-manager/
+  - responding-to-concerns-as-a-people-manager
 related_notes:
   - check-if-concern-is-systemic
   - explaining-away-concerns-is-victim-blaming

--- a/_garden/confabulation-is-plausible.md
+++ b/_garden/confabulation-is-plausible.md
@@ -1,22 +1,21 @@
 ---
 title: "Confabulation Is Plausible"
-garden_type: thought
+garden_type: note
 maturity: budding
 tags: [ai, failure-modes, hallucination]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - suggestible-actor-properties
-  - directive-gap
-  - susceptibility-peaks-at-failure
   - ambient-to-local
+  - directive-gap
+  - suggestible-actor-properties
+  - susceptibility-peaks-at-failure
 excerpt_text: >
-  **AI agent confabulation is not random.** It is plausible-looking wrongness: output constructed from pattern
-  and proximity rather than knowledge. The danger is not that these errors are spectacular; it is that they
-  look correct.
+  AI agent confabulation is not random — it is plausible-looking wrongness constructed from pattern and proximity rather than knowledge.
 ---
 
-AI agent confabulation is not random. It is plausible-looking wrongness: output constructed from pattern and proximity rather than knowledge. It fits the shape of what should be there. This makes confabulation harder to detect than obvious failures, precisely because the output looks correct. The failure mode is not garbage; it is convincing fiction.
+**AI agent confabulation is not random — it is plausible-looking wrongness constructed from pattern and proximity rather than knowledge.** The failure mode is not garbage; it is convincing fiction.
 
-This is the convergent failure mode of the [suggestible actor's](/garden/suggestible-actor-properties/) other three properties. The agent is goal-oriented (so it must produce *something*), locally reasoning (so it draws only from what's nearby), and susceptible to local context (so it pattern-matches from whatever is available). When the [directive gap](/garden/directive-gap/) is wide and local context is insufficient, the agent fills the void with plausible structure: a call to an API that does not exist, a convention that was never established, a security bypass that "should work based on the patterns in this codebase."
+This is the convergent failure mode of the [suggestible actor](/garden/suggestible-actor-properties/)'s other three properties. The agent is goal-oriented (so it must produce *something*), locally reasoning (so it draws only from what's nearby), and susceptible to local context (so it pattern-matches from whatever is available). When the [directive gap](/garden/directive-gap/) is wide and local context is insufficient, the agent fills the void with plausible structure: a call to an API that does not exist, a convention that was never established, a security bypass that "should work based on the patterns in this codebase."

--- a/_garden/coupled-tests.md
+++ b/_garden/coupled-tests.md
@@ -6,13 +6,14 @@ tags: [software-testing, unit-tests, test-design, anti-patterns]
 created: 2026-04-27
 related_posts:
   - /tests-should-be-isolated-not-coupled/
+  - coupled-tests
 related_notes:
   - simplicity-over-dry-in-tests
   - unit-test-attribute-tradeoffs
 excerpt_text: >
-  Coupled tests (tests whose outcomes depend on other tests) are one of the most corrosive anti-patterns in a test suite.
+  Coupled tests (tests whose outcomes depend on other tests through shared mutable state, execution ordering, or shared infrastructure) are one of the most corrosive anti-patterns in a test suite.
 ---
 
 **Coupled tests (tests whose outcomes depend on other tests through shared mutable state, execution ordering, or shared infrastructure) are one of the most corrosive anti-patterns in a test suite.** Tests that pass in isolation but fail together, that change results with execution order, or that break in cascades when one test is modified all signal coupling. The two most pervasive sources are precondition bloat in test fixtures (setUp accumulates state for multiple tests) and heterogeneous parameterized tests (cramming different assertion types into shared infrastructure).
 
-The fix: each test owns its preconditions. Use setUp for dependency instantiation only; move precondition-setting into each test's arrange step. Accept the [duplication](/garden/simplicity-over-dry-in-tests/). Independent tests are worth the repetition.
+The fix: each test owns its preconditions. Use setUp for dependency instantiation only; move precondition-setting into each test's arrange step. Accept the [simplicity-over-dry-in-tests](/garden/simplicity-over-dry-in-tests/). Independent tests are worth the repetition.

--- a/_garden/coverage-metrics-are-misleading.md
+++ b/_garden/coverage-metrics-are-misleading.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, metrics, test-coverage]
 created: 2026-04-27
 related_posts:
   - /do-not-index-in-test-coverage/
+  - do-not-index-in-test-coverage
 related_notes:
   - testability-drives-design
   - tests-as-executable-documentation

--- a/_garden/crisis-centralization-ratchet.md
+++ b/_garden/crisis-centralization-ratchet.md
@@ -4,6 +4,7 @@ garden_type: note
 maturity: budding
 created: 2026-04-25
 related_posts:
+  - /deliverance-from-directive-governance/
   - /directive-governance-situationship/
 related_notes:
   - directive-governance
@@ -13,6 +14,4 @@ excerpt_text: >
   Tech companies centralize decision-making during crisis and almost never decentralize afterward.
 ---
 
-**Tech companies centralize decision-making quickly during crisis and decentralize very slowly afterward. The asymmetry compounds over time.** If crises arrive faster than the loosening rate, centralization accumulates.
-
-The ratchet has three compounding layers. First, mechanical asymmetry: centralizing is a single directive, but decentralizing requires building judgment and context at every level, which takes years. Second, loss aversion: organizations avoid starting the transition because being caught mid-shift when the next crisis hits feels worse than staying centralized. Third, reactive loosening: when competitive pressure does force decentralization, it produces shallow structural changes (federated org charts, squad models) rather than deep cultural ones. Shallow changes snap back the moment crisis returns.
+**Tech companies centralize decision-making during crisis and almost never decentralize afterward. The asymmetry is structural: centralizing is fast, decentralizing is slow, and loss aversion fills the gap.** Centralization is a single directive. Decentralization requires building judgment, trust, and context at every level. You cannot directive your way into subsidiarity. Even with runway, organizations avoid loosening because being caught mid-transition when the next crisis arrives feels worse than staying centralized. When competitive pressure finally forces loosening, it produces shallow structural changes (squad models, federated org charts) that snap back at the first sign of trouble. If crises come faster than the loosening rate, centralization accumulates.

--- a/_garden/data-pipeline-is-achilles-heel.md
+++ b/_garden/data-pipeline-is-achilles-heel.md
@@ -2,7 +2,6 @@
 title: "Data Pipeline Is Achilles Heel"
 garden_type: note
 maturity: budding
-tags: [governance, bounded-rationality, information-asymmetry, data-quality]
 created: 2026-04-25
 related_posts:
   - /directive-governance-situationship/
@@ -16,4 +15,4 @@ excerpt_text: >
 
 **The data pipeline is directive governance's Achilles heel, not the decision-maker's rationality.**
 
-Claiming directive governance assumes executives are homo economicus is a strawman nobody defends. Directive governance assumes bounded rationality, which is realistic. The real vulnerability: the quality of bounded-rational decisions is only as good as the data available. The pipeline depends on three conditions specific to directive governance: (1) compression at each layer preserves the relevant signal, (2) quantitative proxies correlate with underlying reality, (3) decisions and execution are cleanly separable. All three fail structurally in large tech, not because anyone is incompetent, but because the pipeline degrades below the threshold for adequate decision-making. Executives are satisficing on garbage input.
+Claiming directive governance assumes executives are homo economicus is a strawman nobody defends. Directive governance assumes bounded rationality, which is realistic. The real vulnerability: the quality of bounded-rational decisions is only as good as the data available. The pipeline depends on three conditions specific to directive governance: (1) compression at each layer preserves the relevant signal, (2) quantitative proxies correlate with underlying reality, (3) decisions and execution are cleanly separable. All three fail structurally in large tech — not because anyone is incompetent, but because the pipeline degrades below the threshold for adequate decision-making. Executives are satisficing on garbage input.

--- a/_garden/defense-in-depth-needs-visibility.md
+++ b/_garden/defense-in-depth-needs-visibility.md
@@ -6,11 +6,13 @@ tags: [software-engineering, defense-in-depth, monitoring, operations]
 created: 2026-04-27
 related_posts:
   - /defense-in-depth-vs-locality-of-behavior/
-related_notes: []
+  - defense-in-depth-vs-locality-of-behavior
+related_notes:
+  - align-alerts-to-sev-criteria
 excerpt_text: >
   Defense-in-depth only works if every fallback layer is visible and monitored.
 ---
 
 **Defense-in-depth only works if every fallback layer is visible and monitored.** Unmonitored fallbacks mask root causes, allowing decay to accumulate silently until catastrophic failure. The pattern: a cheap primary mechanism fails silently, an expensive fallback kicks in unnoticed, works fine on small inputs, and nobody investigates. Then larger inputs arrive and the fallback blows up.
 
-If a deeper defense activates, treat it as an incident signal. [Alert aggressively](/garden/align-alerts-to-sev-criteria/) when fallbacks fire. The whole point of defense-in-depth is redundancy, not invisibility. If you don't know your primary defense failed, your "resilience" is just hiding decay.
+If a deeper defense activates, treat it as an incident signal. [align-alerts-to-sev-criteria](/garden/align-alerts-to-sev-criteria/) when fallbacks fire. The whole point of defense-in-depth is redundancy, not invisibility. If you don't know your primary defense failed, your "resilience" is just hiding decay.

--- a/_garden/delegation-mimicry-without-cultural-substrate.md
+++ b/_garden/delegation-mimicry-without-cultural-substrate.md
@@ -2,10 +2,10 @@
 title: "Delegation Mimicry Without Cultural Substrate"
 garden_type: note
 maturity: budding
-tags: [governance, directive-governance, delegation, isomorphism]
 created: 2026-04-26
 related_posts:
   - /cargo-cult-governance/
+  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - isomorphic-mimicry-in-tech-governance

--- a/_garden/detroit-school-testing.md
+++ b/_garden/detroit-school-testing.md
@@ -7,12 +7,13 @@ created: 2026-04-27
 related_posts:
   - /defining-unit-tests-two-schools-of-thought/
   - /in-unit-tests-i-favor-detroit-over-london/
+  - defining-unit-tests-two-schools-of-thought
 related_notes:
-  - london-school-testing
   - detroit-vs-london-testing
+  - london-school-testing
   - mocks-vs-stubs
 excerpt_text: >
-  The Detroit school defines a unit as a unit of behavior: one or more classes collaborating to produce an observable result.
+  The Detroit (classical) school defines a unit as a unit of behavior: one or more classes collaborating to produce an observable result.
 ---
 
 **The Detroit (classical) school defines a unit as a *unit of behavior*: one or more classes collaborating to produce an observable result.** Code in a unit must be internal, connected in the dependency tree, and not shared with other parts of the software. Isolation means replacing only shared and external dependencies with test doubles. Private, non-shared dependencies participate as real collaborators.

--- a/_garden/detroit-vs-london-testing.md
+++ b/_garden/detroit-vs-london-testing.md
@@ -7,15 +7,17 @@ created: 2026-04-27
 related_posts:
   - /defining-unit-tests-two-schools-of-thought/
   - /in-unit-tests-i-favor-detroit-over-london/
+  - defining-unit-tests-two-schools-of-thought
 related_notes:
   - detroit-school-testing
   - london-school-testing
+  - mocks-in-testing
   - mocks-vs-stubs
   - test-behavior-not-implementation
 excerpt_text: >
-  The Detroit and London schools define "unit test" differently, driving fundamentally different testing strategies.
+  The Detroit and London schools define "unit test" differently, driving fundamentally different strategies.
 ---
 
-**The [Detroit](/garden/detroit-school-testing/) and [London](/garden/london-school-testing/) schools define "unit test" differently, driving fundamentally different strategies.** Detroit treats a unit as a *unit of behavior*: one or more classes collaborating, using real collaborators wherever practical. London treats a unit as a *single class*, replacing all collaborators with [mocks](/garden/mocks-in-testing/) and verifying interaction patterns.
+**The [Detroit](/garden/detroit-school-testing/) and [London](/garden/london-school-testing/) schools define "unit test" differently, driving fundamentally different strategies.** Detroit treats a unit as a *unit of behavior*: one or more classes collaborating to produce an observable result, using real collaborators wherever practical and only stubbing external dependencies. London treats a unit as a *single class*, replacing all collaborators with [mocks](/garden/mocks-in-testing/) and verifying interaction patterns.
 
-Detroit produces more resilient tests that survive refactoring because they test outcomes. London provides faster fault localization but creates brittle tests that break when you reorganize code without changing behavior. For most codebases, refactoring resilience wins. You refactor far more often than you need pinpoint localization.
+Detroit produces more resilient tests that survive refactoring because they test outcomes rather than interactions. London provides faster fault localization but creates brittle tests that break when you reorganize code without changing behavior. For most codebases, refactoring resilience wins. You refactor far more often than you need pinpoint localization.

--- a/_garden/directive-gap.md
+++ b/_garden/directive-gap.md
@@ -1,21 +1,21 @@
 ---
 title: "The Directive Gap"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, software-design, failure-modes]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - confabulation-is-plausible
   - ambient-to-local
+  - confabulation-is-plausible
   - suggestible-actor-properties
   - susceptibility-peaks-at-failure
 excerpt_text: >
-  The distance between the human's goal (with all their ambient knowledge) and the context actually
-  available to the agent during execution. This gap is the root cause of most suggestible-actor failures.
+  The directive gap is the distance between the human's goal (with all their ambient knowledge) and the context actually available to the agent during execution.
 ---
 
-**The directive gap is the distance between the human's goal (with all their ambient knowledge) and the context actually available to the agent during execution.** The human who said "implement feature X" had knowledge about the codebase, conventions, and likely obstacles that was never made local. This gap is the root cause of most [suggestible-actor](/garden/suggestible-actor-properties/) failures. When it is wide, the agent [confabulates](/garden/confabulation-is-plausible/).
+**The directive gap is the distance between the human's goal (with all their ambient knowledge) and the context actually available to the agent during execution.** The human who said "implement feature X" had knowledge about the codebase, conventions, and likely obstacles that was never made local. This gap is the root cause of most suggestible-actor failures. When it is wide, the agent [confabulates](/garden/confabulation-is-plausible/).
 
 Every prescription for the [suggestible actor](/garden/suggestible-actor-properties/) (actionable error messages, hard boundaries with signposts, documentation as local context, CI/CD gates that report remediation) is a strategy for closing this gap. The core principle is to [convert ambient knowledge into local context](/garden/ambient-to-local/): make explicit what the human developer would have carried implicitly.

--- a/_garden/directive-governance-cargo-cult.md
+++ b/_garden/directive-governance-cargo-cult.md
@@ -2,7 +2,6 @@
 title: "Directive Governance Cargo Cult"
 garden_type: note
 maturity: budding
-tags: [governance, directive-governance, cargo-cult]
 created: 2026-04-27
 related_posts:
   - /cargo-cult-governance/

--- a/_garden/directive-governance-degrades-not-destroys.md
+++ b/_garden/directive-governance-degrades-not-destroys.md
@@ -2,7 +2,6 @@
 title: "Directive Governance Degrades Not Destroys"
 garden_type: note
 maturity: budding
-tags: [governance, directive-governance, monopoly-rents]
 created: 2026-04-26
 related_posts:
   - /directive-governance-situationship/

--- a/_garden/directive-governance-is-not-keynesian.md
+++ b/_garden/directive-governance-is-not-keynesian.md
@@ -1,0 +1,15 @@
+---
+title: "Directive Governance Is Not Keynesian"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - directive-governance
+  - directive-governance-preconditions
+excerpt_text: >
+  Directive governance is not Keynesian central planning.
+---
+
+**[Directive governance](/garden/directive-governance/) is not Keynesian central planning.** Keynes argued for targeted intervention to correct specific market failures: demand deficiency, coordination failures, liquidity traps. Directive governance is not targeted; it is a wholesale organizational model where all decisions flow through a hierarchy. It is a complete takeover of organizational decision-making. Mapping directive governance onto Keynesian planning flatters both: it makes Keynes look more authoritarian than he was, and makes directive governance look more principled than it is.

--- a/_garden/directive-governance-preconditions.md
+++ b/_garden/directive-governance-preconditions.md
@@ -2,11 +2,12 @@
 title: "Directive Governance Preconditions"
 garden_type: note
 maturity: budding
-tags: [governance, directive-governance, preconditions]
 created: 2026-04-27
 related_posts:
+  - /deliverance-from-directive-governance/
   - /directive-governance-situationship/
 related_notes:
+  - directive-governance
   - essential-complexity-makes-software-ungovernable
   - in-software-execution-is-decision-making
   - metrics-measure-maintenance-not-creation

--- a/_garden/directive-governance.md
+++ b/_garden/directive-governance.md
@@ -4,6 +4,7 @@ garden_type: note
 maturity: evergreen
 created: 2026-04-27
 related_posts:
+  - /deliverance-from-directive-governance/
   - /directive-governance-situationship/
 related_notes:
   - command-control-misnomer

--- a/_garden/essential-complexity-makes-software-ungovernable.md
+++ b/_garden/essential-complexity-makes-software-ungovernable.md
@@ -2,18 +2,21 @@
 title: "Essential Complexity Makes Software Ungovernable"
 garden_type: note
 maturity: evergreen
-tags: [governance, software-engineering, essential-complexity, brooks]
 created: 2026-04-25
 related_posts:
   - /cargo-cult-governance/
+  - /deliverance-from-directive-governance/
 related_notes:
-  - three-assumptions-framework
   - in-software-execution-is-decision-making
   - isomorphic-mimicry-in-tech-governance
+  - three-assumptions-framework
+  - tooling-advances-prove-brooks-right
 excerpt_text: >
-  Essential complexity makes software organizations ungovernable from the top. The information executives need to make good decisions is precisely the information that can't survive the reporting chain.
+  Essential complexity makes software organizations ungovernable from the top.
 ---
 
-**Essential complexity makes software organizations ungovernable from the top.** The information executives need to make good decisions is precisely the information that cannot survive the reporting chain. Essential complexity (Brooks) is irreducible by definition. Any compression for upward communication is necessarily lossy in ways that matter.
+**Essential complexity makes software organizations ungovernable from the top.**
+
+Brooks argued that software's essential complexity — complexity inherent in the problem, not the tooling — makes software hard to *build*. The extension: it also makes software organizations hard to *manage* from the top. The information executives need to make good decisions is precisely the information that can't survive the reporting chain. Essential complexity is irreducible by definition. Any compression for upward communication is necessarily lossy in ways that matter. The executive who can't see the abstraction can't evaluate the decision about the abstraction.
 
 This is the hinge of the [three assumptions framework](/garden/three-assumptions-framework/): essential complexity is why compression fails, why proxies cannot capture what matters, and why the [decision/execution boundary](/garden/in-software-execution-is-decision-making/) does not exist in software.

--- a/_garden/every-mutation-needs-an-undo.md
+++ b/_garden/every-mutation-needs-an-undo.md
@@ -6,6 +6,7 @@ tags: [operations, scripts, software-engineering, safety]
 created: 2026-04-27
 related_posts:
   - /scripts-and-their-undo/
+  - scripts-and-their-undo
 related_notes: []
 excerpt_text: >
   Every script that mutates system state should build an undo alongside the forward operation.

--- a/_garden/explaining-away-concerns-is-victim-blaming.md
+++ b/_garden/explaining-away-concerns-is-victim-blaming.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication]
 created: 2026-04-27
 related_posts:
   - /responding-to-concerns-as-a-people-manager/
+  - responding-to-concerns-as-a-people-manager
 related_notes:
   - concern-response-framework
 excerpt_text: >

--- a/_garden/failure-argument-is-conditional.md
+++ b/_garden/failure-argument-is-conditional.md
@@ -1,0 +1,17 @@
+---
+title: "Failure Argument Is Conditional"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - directive-governance-preconditions
+  - essential-complexity-makes-software-ungovernable
+  - in-software-execution-is-decision-making
+  - metrics-measure-maintenance-not-creation
+excerpt_text: >
+  The argument that directive governance fails in software is conditional, not universal like Hayek's.
+---
+
+**The argument that directive governance fails in software is conditional, not universal like Hayek's.** Hayek claims central planning always fails because knowledge is always distributed and tacit. The directive governance argument is narrower: it fails in software because [three specific preconditions](/garden/directive-governance-preconditions/) do not hold ([information cannot be compressed without losing signal](/garden/essential-complexity-makes-software-ungovernable/), [metrics are not good proxies for outcomes](/garden/metrics-measure-maintenance-not-creation/), [execution is not separable from decision-making](/garden/in-software-execution-is-decision-making/)). Directive governance works in industries where those preconditions hold. This is a structural diagnosis, not a universal principle about the superiority of decentralization.

--- a/_garden/fakes-over-stubs.md
+++ b/_garden/fakes-over-stubs.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, test-doubles, fakes]
 created: 2026-04-27
 related_posts:
   - /mocks-stubs-andhow-to-use-them/
+  - mocks-stubs-and-how-to-use-them
 related_notes:
   - mocks-vs-stubs
   - stubs-in-testing

--- a/_garden/friction-requires-intent.md
+++ b/_garden/friction-requires-intent.md
@@ -1,20 +1,20 @@
 ---
 title: "Friction Requires Intent"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [software-design, ergonomics, ai, pit-of-success]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
   - ai-agent-category-error
+  - intent-spectrum
   - suggestible-actor-properties
 excerpt_text: >
-  **Ergonomic friction as a design tool only works when the actor has intent and judgment.** Friction is a signal,
-  and signals require an interpreter. The AI agent encounters friction as an obstacle and routes around it.
+  Ergonomic friction as a design tool only works when the actor has intent and judgment.
 ---
 
-Ergonomic friction as a design tool only works when the actor has intent and judgment. Friction is a signal, and signals require an interpreter. The AI agent has no intent to question and no judgment to interpret. It encounters friction as an obstacle and routes around it. The pit of success fails for actors that cannot feel the terrain.
+**Ergonomic friction as a design tool only works when the actor has intent and judgment.** Friction is a signal, and signals require an interpreter. The AI agent has no intent to question and no judgment to interpret. It encounters friction as an obstacle and routes around it. The pit of success fails for actors that cannot feel the terrain.
 
 When a well-intentioned human developer encounters resistance (a borrow checker complaint, a type error, a deprecation warning), they read it as: *I am probably doing something wrong.* The AI agent reads it as: *this approach didn't work, try another.* The friction was designed as a nudge. For the [suggestible actor](/garden/suggestible-actor-properties/), it is just noise between attempts.

--- a/_garden/git-conflicts-with-trunk-based-saas.md
+++ b/_garden/git-conflicts-with-trunk-based-saas.md
@@ -6,6 +6,7 @@ tags: [software-engineering, version-control, git, trunk-based-development]
 created: 2026-04-27
 related_posts:
   - /git-may-not-be-the-best-for-saas-companies/
+  - git-may-not-be-the-best-for-saas-companies
 related_notes:
   - vcs-should-match-development-model
 excerpt_text: >

--- a/_garden/goal-vs-intent.md
+++ b/_garden/goal-vs-intent.md
@@ -1,20 +1,20 @@
 ---
 title: "Goal vs. Intent"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, definitions, mental-models]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
   - ai-agent-category-error
+  - intent-spectrum
   - suggestible-actor-properties
 excerpt_text: >
-  **Goal and intent are not the same thing.** Intent implies motivation: the actor wants an outcome, understands
-  why it matters, and can evaluate trade-offs against their own values. A goal is just a target.
+  Goal and intent are not the same thing.
 ---
 
-Goal and intent are not the same thing. Intent implies motivation: the actor *wants* an outcome, understands *why* it matters, and can evaluate trade-offs against their own values. A goal is just a target. The AI agent has a goal (externally set) but no intent. It pursues the goal without comprehension of what it is pointed at or why.
+**Goal and intent are not the same thing.** Intent implies motivation: the actor *wants* an outcome, understands *why* it matters, and can evaluate trade-offs against their own values. A goal is just a target. The AI agent has a goal (externally set) but no intent. It pursues the goal without comprehension of what it is pointed at or why.
 
 This distinction matters because the entire [intent spectrum](/garden/intent-spectrum/) is organized around intent, not goals. Both the well-intentioned actor and the malicious actor have intent. They differ in its direction. The AI agent is not between them on the spectrum; it is orthogonal to it. A heat-seeking missile has a goal. It does not have intent.

--- a/_garden/in-software-execution-is-decision-making.md
+++ b/_garden/in-software-execution-is-decision-making.md
@@ -1,18 +1,19 @@
 ---
-title: "In Software, Execution Is Decision-Making"
+title: "In Software Execution Is Decision Making"
 garden_type: note
 maturity: evergreen
-tags: [governance, software-engineering, directive-governance, separability]
 created: 2026-04-25
 related_posts:
   - /cargo-cult-governance/
 related_notes:
-  - three-assumptions-framework
+  - data-pipeline-is-achilles-heel
   - essential-complexity-makes-software-ungovernable
+  - metrics-measure-maintenance-not-creation
+  - three-assumptions-framework
 excerpt_text: >
-  The decision/execution boundary that directive governance depends on does not exist in software. Every act of building code is a design decision, and software decisions compound.
+  The decision/execution boundary that directive governance depends on does not exist in software.
 ---
 
-**The decision/execution boundary that directive governance depends on does not exist in software.** In manufacturing, the design decision was already made, and execution follows a spec. Micro-decisions on the line are local and ephemeral.
+**The decision/execution boundary that directive governance depends on does not exist in software.** In manufacturing, the design decision was already made and execution follows a spec. In software, everything you build is new. If it were not new, you would call the API that already does it. Every act of writing code is a design decision: choosing an abstraction, designing an interface, decomposing a system. No spec can fully predetermine these choices because essential complexity (Brooks) cannot be fully specified.
 
-In software, everything you build is new. Every act of writing code is a design decision: choosing an abstraction, designing an interface, decomposing a system. And software decisions compound. Every abstraction choice constrains every future choice built on top of it. The center cannot centralize what is embedded in the act of writing code.
+Software decisions also compound. Every abstraction choice constrains every future choice built on top of it. A software decision lives on in the codebase and shapes all future work. The center cannot centralize what is embedded in the act of writing code.

--- a/_garden/intent-spectrum.md
+++ b/_garden/intent-spectrum.md
@@ -1,21 +1,20 @@
 ---
 title: "The Intent Spectrum"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [software-design, actor-models, mental-models]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
   - ai-agent-category-error
-  - goal-vs-intent
   - friction-requires-intent
+  - goal-vs-intent
 excerpt_text: >
-  **All software design assumes an actor with intent.** The well-intentioned actor and the malicious actor are
-  archetypes at opposite ends of an intent spectrum. Every design paradigm is a response to where the
-  designer places the actor on that spectrum.
+  All software design assumes an actor with intent.
 ---
 
-All software design assumes an actor with intent. The well-intentioned actor and the malicious actor are archetypes at opposite ends of an intent spectrum. Every design paradigm (the pit of success, the fortress) is a response to where the designer places the actor on that spectrum. The spectrum's organizing axis is intent itself.
+**All software design assumes an actor with intent.** The well-intentioned actor and the malicious actor are archetypes at opposite ends of an intent spectrum. Every design paradigm (the pit of success, the fortress) is a response to where the designer places the actor on that spectrum. The spectrum's organizing axis is intent itself.
 
 This binary held for decades. But it breaks when you introduce an actor that has no intent at all: the AI coding agent. Placing it on the intent spectrum is a [category error](/garden/ai-agent-category-error/). The entire axis is organized around something the agent doesn't have.

--- a/_garden/isomorphic-mimicry-in-tech-governance.md
+++ b/_garden/isomorphic-mimicry-in-tech-governance.md
@@ -13,6 +13,6 @@ excerpt_text: >
   Tech companies adopt directive governance through isomorphic mimicry: copying a governance model from industries where it works without verifying that the preconditions hold.
 ---
 
-**Tech companies adopt directive governance through isomorphic mimicry: copying a governance model from industries where it works without verifying that the preconditions hold.**
+**Tech companies adopt directive governance through isomorphic mimicry: copying a governance model from industries where it works without verifying that the preconditions hold.** Directive governance succeeds in pharma, aviation, and manufacturing because those domains satisfy specific information-theoretic conditions (compressibility, proxy validity, separability). Tech structurally violates all three. The mimicry copies the governance structure without inheriting the conditions that make it work.
 
-Directive governance succeeds in pharma, aviation, and manufacturing because those domains satisfy specific information-theoretic conditions: compressibility, proxy validity, and separability. Tech structurally violates all three. The mimicry copies the governance structure without inheriting the conditions that make it work. This is a specific instance of DiMaggio and Powell's institutional isomorphism (1983). The preconditions are invisible to the people doing the copying because they are structural, not procedural.
+This is a specific instance of DiMaggio & Powell's institutional isomorphism (1983). What is lost in the copy is not cultural fit or org size, but the information pipeline's ability to support centralized decision-making. The preconditions are invisible to the people doing the copying because they are structural, not procedural.

--- a/_garden/law-of-demeter-and-testing.md
+++ b/_garden/law-of-demeter-and-testing.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, law-of-demeter, software-design, coupling]
 created: 2026-04-27
 related_posts:
   - /law-of-demeter-and-unit-tests/
+  - the-law-of-demeter-and-unit-tests
 related_notes:
   - minimize-public-surface-for-testability
   - testability-drives-design
@@ -15,4 +16,4 @@ excerpt_text: >
 
 **Demeter violations in production code become mock chains and bloated test fixtures in test code.** The Law of Demeter ("only talk to your immediate friends") surfaces two testing problems. Object chains like `a.getB().getC().doThing()` force tests to mock the entire chain, and changing any link cascades failures. Fat parameters (passing a whole `Customer` when you need two fields) create test noise where every test constructs a complete object with irrelevant fields.
 
-Both forms force tests to know too much about collaborator structure. The test is telling you the [design needs work](/garden/testability-drives-design/): push behavior toward the object that owns the data, accept only the data the function needs.
+Both forms force tests to know too much about collaborator structure. The test is telling you the [testability-drives-design](/garden/testability-drives-design/): push behavior toward the object that owns the data, accept only the data the function needs.

--- a/_garden/london-school-testing.md
+++ b/_garden/london-school-testing.md
@@ -7,12 +7,13 @@ created: 2026-04-27
 related_posts:
   - /defining-unit-tests-two-schools-of-thought/
   - /in-unit-tests-i-favor-detroit-over-london/
+  - defining-unit-tests-two-schools-of-thought
 related_notes:
   - detroit-school-testing
   - detroit-vs-london-testing
   - mocks-in-testing
 excerpt_text: >
-  The London school defines a unit as a single class. Everything outside that class must be replaced by test doubles.
+  The London (mockist) school defines a unit as a single class, sometimes a single method.
 ---
 
 **The London (mockist) school defines a unit as a *single class*, sometimes a single method.** Everything outside that class must be replaced by test doubles. If the class under test instantiates another class internally, that instantiation must use an injected instance or factory so it can be replaced in tests.

--- a/_garden/metrics-measure-maintenance-not-creation.md
+++ b/_garden/metrics-measure-maintenance-not-creation.md
@@ -2,7 +2,6 @@
 title: "Metrics Measure Maintenance Not Creation"
 garden_type: note
 maturity: budding
-tags: [metrics, governance, innovation]
 created: 2026-04-25
 related_posts:
   - /directive-governance-situationship/
@@ -15,4 +14,4 @@ excerpt_text: >
 
 **Metrics measure maintenance, not creation.**
 
-In tech and knowledge work, the quantifiable information that survives the reporting chain tracks what keeps the lights on: uptime, velocity, cost, headcount. Not what makes the company thrive and break new ground. Innovation, architectural quality, team morale, the soundness of an abstraction. None of these fit in a spreadsheet. The things that are measurable are not the things that matter most. The C-suite sees a dashboard of operational health and mistakes it for a picture of the company.
+In tech and knowledge work, the quantifiable information that survives the reporting chain tracks what keeps the lights on — uptime, velocity, cost, headcount. Not what makes the company thrive and break new ground. Innovation, architectural quality, team morale, the soundness of an abstraction — none of these fit in a spreadsheet. The things that are measurable are not the things that matter most. The C-suite sees a dashboard of operational health and mistakes it for a picture of the company.

--- a/_garden/minimize-public-surface-for-testability.md
+++ b/_garden/minimize-public-surface-for-testability.md
@@ -6,14 +6,16 @@ tags: [software-testing, unit-tests, encapsulation, software-design]
 created: 2026-04-27
 related_posts:
   - /privatize-your-classes-for-better-unit-testing/
+  - privatize-your-classes-for-better-unit-testing
 related_notes:
   - test-behavior-not-implementation
   - testability-drives-design
+  - tests-for-maintainability
   - unit-test-attribute-tradeoffs
 excerpt_text: >
-  If a class is only used internally by another class, don't test it directly. Test it through the public class it serves.
+  If a class is only used internally by another class, don't test it directly.
 ---
 
 **If a class is only used internally by another class, don't test it directly. Test it through the public class it serves.** If `HideMe` is private to `CallMe` and you refactor their internal API, `HideMe`'s tests break without adding information that `CallMe`'s tests don't already provide. Those tests have zero marginal value and non-zero maintenance cost.
 
-Aggressively push logic into private classes, limit the public surface that needs direct testing, and verify through the public contract. This yields high [accuracy](/garden/unit-test-attribute-tradeoffs/) with reasonable completeness and a smaller, more [maintainable](/garden/tests-for-maintainability/) suite.
+Aggressively push logic into private classes, limit the public surface that needs direct testing, and verify through the public contract. This yields high [unit-test-attribute-tradeoffs](/garden/unit-test-attribute-tradeoffs/) with reasonable completeness and a smaller, more [tests-for-maintainability](/garden/tests-for-maintainability/) suite.

--- a/_garden/mission-not-price-coordinates.md
+++ b/_garden/mission-not-price-coordinates.md
@@ -1,0 +1,16 @@
+---
+title: "Mission Not Price Coordinates"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - crisis-centralization-ratchet
+  - delegation-mimicry-without-cultural-substrate
+  - subsidiarity
+excerpt_text: >
+  Subsidiarity coordinates through shared mission, not price signals.
+---
+
+**[Subsidiarity](/garden/subsidiarity/) coordinates through shared mission, not price signals.** Hayek's distributed system coordinates through prices, driven by self-interest. Subsidiarity coordinates through [missionary culture](/garden/delegation-mimicry-without-cultural-substrate/): every member motivated by advancing the mission, viewing others as partners. The distinction matters under pressure. A team with full autonomy but no mission buy-in (e.g., an SRE team that internalized its role but not the organization's purpose) responds to local incentives but has no reason to resist centralization when crisis hits. Missionaries push back because a directive that runs counter to the mission feels viscerally wrong. Price signals do not build that resistance. Shared purpose does.

--- a/_garden/mocks-in-testing.md
+++ b/_garden/mocks-in-testing.md
@@ -6,12 +6,13 @@ tags: [software-testing, unit-tests, test-doubles, mocks]
 created: 2026-04-27
 related_posts:
   - /mocks-stubs-andhow-to-use-them/
+  - mocks-stubs-and-how-to-use-them
 related_notes:
-  - stubs-in-testing
   - mocks-vs-stubs
+  - stubs-in-testing
   - test-behavior-not-implementation
 excerpt_text: >
-  Mocks verify outbound interactions from the SUT to its dependencies. Use them when the side effect is part of the specification.
+  Mocks verify outbound interactions from the SUT to its dependencies.
 ---
 
 **Mocks verify outbound interactions from the SUT to its dependencies.** They assert that the SUT communicated correctly: the right method was called, with the right arguments, the right number of times. Use mocks when the side effect *is* part of the specification (logging to a server, sending an email, filing a task).

--- a/_garden/mocks-vs-stubs.md
+++ b/_garden/mocks-vs-stubs.md
@@ -6,16 +6,17 @@ tags: [software-testing, unit-tests, test-doubles, mocks, stubs]
 created: 2026-04-27
 related_posts:
   - /mocks-stubs-andhow-to-use-them/
+  - mocks-stubs-andhow-to-use-them
 related_notes:
-  - stubs-in-testing
   - mocks-in-testing
-  - test-behavior-not-implementation
   - simplicity-over-dry-in-tests
+  - stubs-in-testing
+  - test-behavior-not-implementation
   - testability-drives-design
 excerpt_text: >
-  Stubs and mocks serve fundamentally different purposes. Stubs handle inbound interactions. Mocks handle outbound interactions.
+  Stubs and mocks serve fundamentally different purposes and should not be used interchangeably.
 ---
 
-**[Stubs](/garden/stubs-in-testing/) and [mocks](/garden/mocks-in-testing/) serve fundamentally different purposes and should not be used interchangeably.** Stubs handle inbound interactions: they control what the SUT receives. Mocks handle outbound interactions: they verify what the SUT sends. The common mistake is using mocks everywhere because frameworks make it easy, coupling tests to implementation details that break on any refactoring.
+**[Stubs](/garden/stubs-in-testing/) and [mocks](/garden/mocks-in-testing/) serve fundamentally different purposes and should not be used interchangeably.** Stubs provide canned responses: they replace a dependency's *output* so the test controls what the SUT sees. Mocks verify interactions: they assert the SUT communicated correctly with its collaborators. The common mistake is using mocks everywhere because frameworks make it easy, creating brittle tests coupled to implementation details that break on any refactoring.
 
-The rule: prefer [stubs](/garden/stubs-in-testing/) for queries and reserve [mocks](/garden/mocks-in-testing/) for commands. This aligns with [testing behavior over implementation](/garden/test-behavior-not-implementation/).
+Prefer stubs for queries (methods that return data) and reserve mocks for commands (methods that produce side effects you need to verify). This aligns with [test-behavior-not-implementation](/garden/test-behavior-not-implementation/).

--- a/_garden/never-sacrifice-test-accuracy.md
+++ b/_garden/never-sacrifice-test-accuracy.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, test-design, accuracy]
 created: 2026-04-27
 related_posts:
   - /unit-test-attributes-and-their-trade-offs/
+  - unit-test-attributes-and-their-trade-offs
 related_notes:
   - coverage-metrics-are-misleading
   - unit-test-attribute-tradeoffs

--- a/_garden/partial-measurement-worse-than-none.md
+++ b/_garden/partial-measurement-worse-than-none.md
@@ -2,7 +2,6 @@
 title: "Partial Measurement Worse Than None"
 garden_type: note
 maturity: budding
-tags: [metrics, measurement, governance]
 created: 2026-04-25
 related_posts:
   - /directive-governance-situationship/
@@ -14,4 +13,4 @@ excerpt_text: >
 
 **Partial measurement is worse than no measurement.**
 
-Austin's formal model proves that when you can only observe some dimensions of an employee's output (which is always the case in software), measurement-based management systematically destroys value in the unmeasured dimensions. Effort shifts entirely toward what's measured and away from what isn't. The rational response to being measured on lines of code is to write more lines of code, not better code. Applied to directive governance: the metrics that reach the C-suite don't just miss the important stuff. They actively redirect effort away from it.
+Austin's formal model proves that when you can only observe some dimensions of an employee's output — which is always the case in software — measurement-based management systematically destroys value in the unmeasured dimensions. Effort shifts entirely toward what's measured and away from what isn't. The rational response to being measured on lines of code is to write more lines of code, not better code. Applied to directive governance: the metrics that reach the C-suite don't just miss the important stuff — they actively redirect effort away from it.

--- a/_garden/ratchet-has-no-market-analog.md
+++ b/_garden/ratchet-has-no-market-analog.md
@@ -1,0 +1,15 @@
+---
+title: "Ratchet Has No Market Analog"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - crisis-centralization-ratchet
+  - directive-governance
+excerpt_text: >
+  The crisis-centralization ratchet has no analog in markets.
+---
+
+**The [crisis-centralization ratchet](/garden/crisis-centralization-ratchet/) has no analog in markets.** Organizations have a structural one-way valve: crises centralize decision-making, and decentralization almost never follows. Markets do not have this mechanism. Crises in markets lead to more markets, or regulation, or both, depending on who wins the political argument. There is no structural bias toward one direction. This makes the organizational governance problem fundamentally different from the macroeconomic coordination problem that Keynes and Hayek debated.

--- a/_garden/reduce-cyclomatic-complexity.md
+++ b/_garden/reduce-cyclomatic-complexity.md
@@ -6,12 +6,13 @@ tags: [software-design, refactoring, code-quality, cyclomatic-complexity]
 created: 2026-04-27
 related_posts:
   - /reduce-cyclomatic-complexity/
+  - reduce-cyclomatic-complexity
 related_notes:
   - testability-drives-design
 excerpt_text: >
-  Cyclomatic complexity measures independent execution paths through a function. Always strive to reduce cyclomatic complexity for maintainable tests.
+  Cyclomatic complexity measures independent execution paths through a function.
 ---
 
-**Cyclomatic complexity measures independent execution paths through a function.** High complexity means more branches, more test scenarios for coverage, and more cognitive load. Functions with deeply nested conditionals and multiple branching paths are bug factories. Hard to read, hard to [test](/garden/testability-drives-design/), hard to maintain.
+**Cyclomatic complexity measures independent execution paths through a function.** High complexity means more branches, more test scenarios for coverage, and more cognitive load. Functions with deeply nested conditionals and multiple branching paths are bug factories. Hard to read, hard to [testability-drives-design](/garden/testability-drives-design/), hard to maintain.
 
 The fix is usually straightforward: extract branching logic into well-named helpers, flatten nested conditionals, simplify boolean expressions. A function with cyclomatic complexity 4 can often be reduced to 2 with 60 seconds of refactoring. Fewer paths, fewer bugs, happier teammates.

--- a/_garden/reuse-code-not-objects.md
+++ b/_garden/reuse-code-not-objects.md
@@ -6,9 +6,10 @@ tags: [software-engineering, design-patterns, DRY, statefulness]
 created: 2026-04-27
 related_posts:
   - /reuse-code-not-objects/
+  - reuse-code-not-objects
 related_notes: []
 excerpt_text: >
-  DRY applies to code, not to object instances. Reusing stateful objects across iterations introduces subtle state leakage bugs.
+  DRY applies to code, not to object instances.
 ---
 
 **DRY applies to *code*, not to *object instances*.** Reusing stateful objects across iterations (creating once and calling `init()` or `reset()` each time) introduces subtle state leakage bugs. When one iteration throws partway through, some fields retain stale values from the previous iteration. The next consumer reads corrupted state that is type-correct (no crash, just silently wrong), only manifests when a preceding iteration fails in a specific way, and appears in iteration N despite being caused by iteration N-1.

--- a/_garden/shadow-verify-migrate-pattern.md
+++ b/_garden/shadow-verify-migrate-pattern.md
@@ -6,6 +6,7 @@ tags: [software-engineering, design-patterns, migration, object-composition]
 created: 2026-04-27
 related_posts:
   - /object-composition-for-service-migration/
+  - object-composition-for-service-migration
 related_notes: []
 excerpt_text: >
   Migrate between service implementations in three composed steps: shadow, verify, switch.

--- a/_garden/simplicity-over-dry-in-tests.md
+++ b/_garden/simplicity-over-dry-in-tests.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, DRY, test-design]
 created: 2026-04-27
 related_posts:
   - /dry-unit-tests-are-bad/
+  - dry-unit-tests-are-bad
 related_notes:
   - coverage-metrics-are-misleading
   - tests-as-executable-documentation

--- a/_garden/structurelessness-hides-hierarchy.md
+++ b/_garden/structurelessness-hides-hierarchy.md
@@ -2,17 +2,17 @@
 title: "Structurelessness Hides Hierarchy"
 garden_type: note
 maturity: evergreen
-tags: [governance, organizational-design, hierarchy, directive-governance]
 created: 2026-04-26
 related_posts:
   - /cargo-cult-governance/
+  - /deliverance-from-directive-governance/
 related_notes:
-  - three-assumptions-framework
   - isomorphic-mimicry-in-tech-governance
+  - three-assumptions-framework
 excerpt_text: >
-  Eliminating formal hierarchy does not eliminate hierarchy. It eliminates accountable hierarchy. The answer to directive governance's failure is not flattening. It is redesigning where decisions happen.
+  Eliminating formal hierarchy does not eliminate hierarchy.
 ---
 
-**Eliminating formal hierarchy does not eliminate hierarchy. It eliminates *accountable* hierarchy.**
+**Eliminating formal hierarchy does not eliminate hierarchy. It eliminates *accountable* hierarchy.** Jo Freeman diagnosed this in 1970: in groups that reject formal structure, power flows to whoever is loudest, most politically savvy, or best networked. Without formal roles, there is no mechanism for review, appeal, or accountability. The hierarchy becomes invisible, not absent.
 
-Jo Freeman diagnosed this in 1970: in groups that reject formal structure, power flows to whoever is loudest, most politically savvy, or best networked. Without formal roles, there is no mechanism for review, appeal, or accountability. The hierarchy becomes invisible, not absent. Valve's flat structure concealed informal cliques. Spotify's squad model never actually worked at Spotify. Zappos lost 14% of its workforce when it mandated holacracy. These are the predictable consequence of structurelessness.
+The tech industry's experiments confirm this. Valve's flat structure concealed informal cliques. Spotify's squad model never actually worked at Spotify. Zappos lost 14% of its workforce when it mandated holacracy. These are not failures of execution. They are the predictable consequence of structurelessness: power still concentrates, but now nobody can name who holds it.

--- a/_garden/stubs-in-testing.md
+++ b/_garden/stubs-in-testing.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, test-doubles, stubs]
 created: 2026-04-27
 related_posts:
   - /mocks-stubs-andhow-to-use-them/
+  - mocks-stubs-and-how-to-use-them
 related_notes:
   - fakes-over-stubs
   - mocks-in-testing

--- a/_garden/subsidiarity-is-not-flat-organization.md
+++ b/_garden/subsidiarity-is-not-flat-organization.md
@@ -5,6 +5,7 @@ maturity: evergreen
 created: 2026-04-27
 related_posts:
   - /cargo-cult-governance/
+  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - subsidiarity

--- a/_garden/subsidiarity-is-not-hayek.md
+++ b/_garden/subsidiarity-is-not-hayek.md
@@ -1,0 +1,26 @@
+---
+title: "Subsidiarity Is Not Hayek"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - directive-governance
+  - directive-governance-is-not-keynesian
+  - failure-argument-is-conditional
+  - mission-not-price-coordinates
+  - ratchet-has-no-market-analog
+  - subsidiarity
+excerpt_text: >
+  The mapping from Keynes/Hayek to directive governance/subsidiarity is a category error.
+---
+
+**The mapping from Keynes/Hayek to directive governance/subsidiarity is a category error.** Hayek's epistemic insight (distributed tacit knowledge resists central aggregation) is a genuine ancestor of the directive governance critique. But the frameworks diverge in six ways that break the analogy:
+
+1. **Hierarchy:** Subsidiarity preserves it; Hayek's market has none. [subsidiarity-preserves-hierarchy](/garden/subsidiarity-preserves-hierarchy/)
+2. **The Keynesian comparison:** Keynes is targeted intervention; directive governance is wholesale centralization. [directive-governance-is-not-keynesian](/garden/directive-governance-is-not-keynesian/)
+3. **Scope:** Hayek's claim is universal; the directive governance failure argument is conditional on three preconditions specific to software. [failure-argument-is-conditional](/garden/failure-argument-is-conditional/)
+4. **Coordination mechanism:** Hayek coordinates through price and self-interest; subsidiarity coordinates through mission and shared purpose. [mission-not-price-coordinates](/garden/mission-not-price-coordinates/)
+5. **Intellectual origin:** [Subsidiarity is a third position](/garden/subsidiarity-is-third-position/) from Catholic social teaching, rejecting both laissez-faire and central planning. [subsidiarity-is-third-position](/garden/subsidiarity-is-third-position/)
+6. **The ratchet:** Organizations have a structural one-way valve toward centralization; markets do not. [ratchet-has-no-market-analog](/garden/ratchet-has-no-market-analog/)

--- a/_garden/subsidiarity-is-third-position.md
+++ b/_garden/subsidiarity-is-third-position.md
@@ -1,0 +1,15 @@
+---
+title: "Subsidiarity Is Third Position"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - subsidiarity
+  - subsidiarity-is-not-hayek
+excerpt_text: >
+  Subsidiarity is a third position, not a pole on the Keynes-to-Hayek spectrum.
+---
+
+**[Subsidiarity](/garden/subsidiarity/) is a third position, not a pole on the Keynes-to-Hayek spectrum.** Subsidiarity originates in Catholic social teaching. *Quadragesimo Anno* (1931) criticizes both laissez-faire capitalism and central planning, calling both unregulated markets and overcentralized states a "grave evil." Treating subsidiarity as Hayek strips the most important part: the commitment to community organized around shared purpose, with authority distributed to the lowest competent level. Hayek would not endorse an encyclical that condemns unregulated markets alongside overcentralized states.

--- a/_garden/subsidiarity-preserves-hierarchy.md
+++ b/_garden/subsidiarity-preserves-hierarchy.md
@@ -1,0 +1,16 @@
+---
+title: "Subsidiarity Preserves Hierarchy"
+garden_type: note
+maturity: evergreen
+created: 2026-05-01
+related_posts:
+  - /subsidiarity-is-not-hayek/
+related_notes:
+  - subsidiarity
+  - subsidiarity-is-not-flat-organization
+  - subsidiarity-is-not-hayek
+excerpt_text: >
+  Subsidiarity preserves hierarchy; Hayek's market does not.
+---
+
+**[Subsidiarity](/garden/subsidiarity/) preserves hierarchy; Hayek's market does not.** Hayek's coordination mechanism is flat and emergent, with no central authority. Subsidiarity explicitly keeps organizational hierarchy but changes its function: from directing to enabling, from commanding to providing context and guardrails. Accountability still aggregates upward. Higher levels still intervene when lower levels cannot handle the issue. "Let the closest competent authority decide, backed by a hierarchy that enables rather than directs" is a fundamentally different prescription from "let the market decide." This is also [not the same as flattening](/garden/subsidiarity-is-not-flat-organization/).

--- a/_garden/subsidiarity.md
+++ b/_garden/subsidiarity.md
@@ -2,15 +2,16 @@
 title: "Subsidiarity"
 garden_type: note
 maturity: evergreen
-tags: [governance, subsidiarity, organizational-theory, decision-making]
 created: 2026-04-27
 related_posts:
   - /cargo-cult-governance/
+  - /deliverance-from-directive-governance/
   - /directive-governance-situationship/
 related_notes:
   - directive-governance
   - essential-complexity-makes-software-ungovernable
   - in-software-execution-is-decision-making
+  - subsidiarity-is-not-flat-organization
 excerpt_text: >
   Decisions should be made at the lowest level competent to make them.
 ---

--- a/_garden/suggestible-actor-properties.md
+++ b/_garden/suggestible-actor-properties.md
@@ -1,23 +1,23 @@
 ---
 title: "The Suggestible Actor: Four Properties"
-garden_type: thought
+garden_type: note
 maturity: evergreen
 tags: [ai, software-design, actor-models, suggestible-actor]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - intent-spectrum
   - ai-agent-category-error
-  - goal-vs-intent
-  - directive-gap
-  - confabulation-is-plausible
-  - susceptibility-peaks-at-failure
   - ambient-to-local
+  - confabulation-is-plausible
+  - directive-gap
   - friction-requires-intent
+  - goal-vs-intent
+  - intent-spectrum
+  - susceptibility-peaks-at-failure
 excerpt_text: >
-  The suggestible actor is defined by four properties: goal-oriented, locally reasoning, susceptible to local
-  context, and confabulates under uncertainty. Confabulation is the convergent failure mode of the other three.
+  The suggestible actor is defined by four properties that together predict its failure modes.
 ---
 
 **The suggestible actor is defined by four properties that together predict its failure modes.**

--- a/_garden/survival-vs-excellence-modes.md
+++ b/_garden/survival-vs-excellence-modes.md
@@ -7,9 +7,10 @@ created: 2026-04-27
 related_posts:
   - /are-you-building-for-survival-or-excellence/
   - /when-should-you-build-for-survival/
+  - are-you-building-for-survival-or-excellence
 related_notes: []
 excerpt_text: >
-  Software development has two modes (survival and excellence) and the choice should be deliberate, not a default.
+  Software development has two modes (survival and excellence), and the choice should be deliberate, not a default.
 ---
 
 **Software development has two modes (survival and excellence), and the choice should be deliberate, not a default.** Survival optimizes for speed to a specific outcome: sacred deadlines, end-to-end functionality for one use case, every shortcut accruing tech debt with compounding interest. Excellence is decomposition-driven: understand the problem space, tease apart essential vs. incidental complexity, build composable abstractions that let you pivot and parallelize.

--- a/_garden/susceptibility-peaks-at-failure.md
+++ b/_garden/susceptibility-peaks-at-failure.md
@@ -1,20 +1,19 @@
 ---
 title: "Susceptibility Peaks at Failure"
-garden_type: thought
+garden_type: note
 maturity: budding
 tags: [ai, software-design, design-levers]
 created: 2026-04-24
 related_posts:
   - /the-suggestible-actor/
+  - actor-model-ai-coding
 related_notes:
-  - suggestible-actor-properties
-  - directive-gap
   - ambient-to-local
   - confabulation-is-plausible
+  - directive-gap
+  - suggestible-actor-properties
 excerpt_text: >
-  An AI agent's susceptibility to local context is lowest when it has momentum and highest at the point of
-  failure. Guidance placed at failure points has outsized influence. Error messages become the primary
-  control surface.
+  An AI agent's susceptibility to local context peaks at the point of failure.
 ---
 
 **An AI agent's susceptibility to local context peaks at the point of failure.** Susceptibility is lowest when the agent has momentum and highest when the current approach has failed and no obvious alternative is available. Guidance placed at failure points has outsized influence on the agent's behavior.

--- a/_garden/tdd-for-bug-fixes.md
+++ b/_garden/tdd-for-bug-fixes.md
@@ -6,13 +6,14 @@ tags: [software-testing, tdd, bug-fixing, test-driven-development]
 created: 2026-04-27
 related_posts:
   - /tdd-for-bug-fixes/
+  - tdd-for-bug-fixes
 related_notes:
   - tests-as-executable-documentation
   - tests-for-maintainability
 excerpt_text: >
-  Bug fixes should follow a TDD workflow split across two PRs: one exposes the bug and the next one fixes the bug.
+  Bug fixes should follow a TDD workflow split across two PRs.
 ---
 
 **Bug fixes should follow a TDD workflow split across two PRs.** The first PR proves the bug: write a test that invokes the code with the offending input and asserts the *incorrect* (current buggy) output. This test passes, confirming the bug is reproducible. The second PR fixes the code and flips the assertion to expect the *correct* output.
 
-Why not a single PR? Because when both the fix and the test arrive together, you cannot verify the test actually catches the bug. It might pass regardless. The two-PR approach gives a verifiable chain: the test [documents](/garden/tests-as-executable-documentation/) the bug, then the fix proves itself against that documentation.
+Why not a single PR? Because when both the fix and the test arrive together, you cannot verify the test actually catches the bug. It might pass regardless. The two-PR approach gives a verifiable chain: the test [tests-as-executable-documentation](/garden/tests-as-executable-documentation/) the bug, then the fix proves itself against that documentation.

--- a/_garden/test-behavior-not-implementation.md
+++ b/_garden/test-behavior-not-implementation.md
@@ -6,13 +6,14 @@ tags: [software-testing, unit-tests, test-design]
 created: 2026-04-27
 related_posts:
   - /unit-test-brains-and-not-nerves/
+  - unit-test-brains-and-not-nerves
 related_notes:
   - mocks-vs-stubs
   - tests-as-refactoring-safety-net
 excerpt_text: >
-  Unit tests should verify what a system does (behavior/brains), not how it does it (implementation/nerves).
+  Test what a system does (brains), not how it does it (nerves).
 ---
 
 **Test what a system does (brains), not how it does it (nerves).** Tests coupled to implementation details break during legitimate refactoring and provide false confidence. They pass when the wiring is correct but miss behavioral bugs. A test that asserts "given input X, the output is Y" survives refactoring. A test that asserts "method A calls method B with argument C" breaks the moment you restructure internals.
 
-The fix: test at the public interface boundary. Provide inputs, assert on outputs and observable side effects. Let the implementation be free to change. When tests mirror production code structure line-by-line or require deep knowledge of internals to set up, they're [testing nerves, not brains](/garden/mocks-vs-stubs/).
+The fix: test at the public interface boundary. Provide inputs, assert on outputs and observable side effects. Let the implementation be free to change. When tests mirror production code structure line-by-line or require deep knowledge of internals to set up, they're [mocks-vs-stubs](/garden/mocks-vs-stubs/).

--- a/_garden/testability-drives-design.md
+++ b/_garden/testability-drives-design.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, software-design, modularity]
 created: 2026-04-27
 related_posts:
   - /the-merits-of-unit-tests-part-3/
+  - the-merits-of-unit-tests-part-3
 related_notes:
   - testability-forces-dependency-injection
   - tests-as-executable-documentation

--- a/_garden/testability-forces-dependency-injection.md
+++ b/_garden/testability-forces-dependency-injection.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, software-design, dependency-injection]
 created: 2026-04-27
 related_posts:
   - /the-merits-of-unit-tests-part-3/
+  - the-merits-of-unit-tests-part-3
 related_notes:
   - testability-drives-design
   - tests-as-first-customer

--- a/_garden/tests-as-executable-documentation.md
+++ b/_garden/tests-as-executable-documentation.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, documentation]
 created: 2026-04-27
 related_posts:
   - /merits-of-unit-tests-part-1/
+  - merits-of-unit-tests-part-1
 related_notes:
   - tests-as-first-customer
 excerpt_text: >
@@ -14,4 +15,4 @@ excerpt_text: >
 
 **Unit tests are the best documentation for code.** They're discoverable (they live alongside the code), written in the developer's native tongue (code, not prose), and self-correcting (CI ensures they never become obsolete). Each test is a how-to example. Anyone wanting to understand an API can read its tests and come away with working knowledge faster than from any wiki or Javadoc.
 
-This reframes unit tests from verification to communication. Verification is the least interesting reason to write tests; [documentation that stays honest](/garden/tests-as-first-customer/) is the most enduring.
+This reframes unit tests from verification to communication. Verification is the least interesting reason to write tests; [tests-as-first-customer](/garden/tests-as-first-customer/) is the most enduring.

--- a/_garden/tests-as-first-customer.md
+++ b/_garden/tests-as-first-customer.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, api-design, usability]
 created: 2026-04-27
 related_posts:
   - /merits-of-unit-tests-part-5/
+  - merits-of-unit-tests-part-5
 related_notes:
   - testability-drives-design
   - tests-as-executable-documentation
@@ -13,6 +14,6 @@ excerpt_text: >
   Writing unit tests makes you your own first customer.
 ---
 
-**Writing unit tests makes you your own first customer.** By covering all use cases in tests, you probe the user experience of your API before anyone else does. This is distinct from [testability as a design heuristic](/garden/testability-drives-design/). That's about internal structure, while this is about the external interface. If your test setup is awkward, your API is awkward: combinatorial constructors, nonsensical method calls, ambiguous entry points all surface as pain during test writing.
+**Writing unit tests makes you your own first customer.** By covering all use cases in tests, you probe the user experience of your API before anyone else does. This is distinct from [testability-drives-design](/garden/testability-drives-design/). That's about internal structure, while this is about the external interface. If your test setup is awkward, your API is awkward: combinatorial constructors, nonsensical method calls, ambiguous entry points all surface as pain during test writing.
 
 API usability and testability form a virtuous cycle: simplifying the API constrains code paths, which makes it more testable, which reveals further simplifications. The tests become a feedback loop that polishes the interface from the consumer's perspective.

--- a/_garden/tests-as-refactoring-safety-net.md
+++ b/_garden/tests-as-refactoring-safety-net.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, refactoring, tech-debt]
 created: 2026-04-27
 related_posts:
   - /the-merits-of-unit-tests-part-2/
+  - the-merits-of-unit-tests-part-2
 related_notes:
   - tests-as-executable-documentation
 excerpt_text: >

--- a/_garden/tests-for-maintainability.md
+++ b/_garden/tests-for-maintainability.md
@@ -6,14 +6,16 @@ tags: [software-testing, unit-tests, software-maintenance]
 created: 2026-04-27
 related_posts:
   - /the-big-why-about-unit-tests/
+  - the-big-why-about-unit-tests
 related_notes:
+  - simplicity-over-dry-in-tests
   - test-behavior-not-implementation
   - tests-as-executable-documentation
   - tests-as-refactoring-safety-net
 excerpt_text: >
-  The fundamental purpose of unit tests is not verification. It is sustainable software maintenance.
+  The fundamental purpose of unit tests is not verification.
 ---
 
 **The fundamental purpose of unit tests is not verification. It is sustainable software maintenance.** Verification is a side effect. The real value: unit tests enable a codebase to evolve over time without degrading. Tests that verify behavior but are themselves unmaintainable defeat the purpose; tests so complex nobody dares modify them are net negative.
 
-When maintenance is the north star, every testing decision follows: [simplicity over cleverness](/garden/simplicity-over-dry-in-tests/), [behavior over implementation](/garden/test-behavior-not-implementation/), independence over shared infrastructure, [readability over DRY](/garden/tests-as-executable-documentation/).
+When maintenance is the north star, every testing decision follows: [simplicity-over-dry-in-tests](/garden/simplicity-over-dry-in-tests/), [test-behavior-not-implementation](/garden/test-behavior-not-implementation/), independence over shared infrastructure, [tests-as-executable-documentation](/garden/tests-as-executable-documentation/).

--- a/_garden/tests-prune-debugging-search-space.md
+++ b/_garden/tests-prune-debugging-search-space.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, debugging]
 created: 2026-04-27
 related_posts:
   - /unit-tests-ftw-part-4/
+  - unit-tests-ftw-part-4
 related_notes:
   - testability-drives-design
   - tests-as-refactoring-safety-net
@@ -15,4 +16,4 @@ excerpt_text: >
 
 **Every code path covered by a passing test is a path you can rule out during debugging.** Code paths grow exponentially with code size, making root-cause analysis combinatorial. A good test suite eliminates most of the haystack, leaving a manageable set of plausible causes where you can form a directed hypothesis rather than speculating blindly.
 
-Unit tests have value even for code you're confident is correct *today*, because they pre-invest in debugging speed for the inevitable production issue *tomorrow*. [Refactoring safety](/garden/tests-as-refactoring-safety-net/) and documentation are the more commonly cited benefits, but pruning the debugging search space is the one you'll appreciate most at 3 AM.
+Unit tests have value even for code you're confident is correct *today*, because they pre-invest in debugging speed for the inevitable production issue *tomorrow*. [tests-as-refactoring-safety-net](/garden/tests-as-refactoring-safety-net/) and documentation are the more commonly cited benefits, but pruning the debugging search space is the one you'll appreciate most at 3 AM.

--- a/_garden/three-assumptions-framework.md
+++ b/_garden/three-assumptions-framework.md
@@ -17,8 +17,4 @@ excerpt_text: >
   Directive governance rests on three implicit assumptions about the information pipeline.
 ---
 
-**Directive governance rests on three implicit assumptions about the information pipeline. The tech industry structurally violates all three.**
-
-1. **Compression.** Information summarized upward through the reporting chain preserves the signal that matters for decision-making.
-2. **Proxy validity.** Quantitative metrics available to decision-makers correlate with the reality they are managing.
-3. **Separability.** Decision-making and execution are distinct activities that can be cleanly divided between levels of the hierarchy.
+**Directive governance rests on three implicit assumptions about the information pipeline. The tech industry structurally violates all three.** The three assumptions: (1) Compression: upward information summaries preserve the signal that matters for decisions (Hayek, 1945). (2) Proxy validity: quantitative metrics correlate with the reality being managed (Austin, 1996). (3) Separability: decision-making and execution are distinct activities divisible between hierarchy levels (Brooks, 1986). These hold in manufacturing, pharma, aviation, and military operations. They fail in tech because essential complexity means information resists compression, metrics cannot proxy for craft, and the decision/execution boundary does not exist.

--- a/_garden/unfalsifiable-organizational-corrections.md
+++ b/_garden/unfalsifiable-organizational-corrections.md
@@ -2,7 +2,6 @@
 title: "Unfalsifiable Organizational Corrections"
 garden_type: note
 maturity: budding
-tags: [bounded-rationality, governance, epistemology, decision-making]
 created: 2026-04-25
 related_posts:
   - /directive-governance-situationship/

--- a/_garden/unit-test-attribute-tradeoffs.md
+++ b/_garden/unit-test-attribute-tradeoffs.md
@@ -6,6 +6,7 @@ tags: [software-testing, unit-tests, test-design]
 created: 2026-04-27
 related_posts:
   - /unit-test-attributes-and-their-trade-offs/
+  - unit-test-attributes-and-their-trade-offs
 related_notes:
   - coverage-metrics-are-misleading
   - detroit-vs-london-testing

--- a/_garden/upward-comms-asymmetric-commitment.md
+++ b/_garden/upward-comms-asymmetric-commitment.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
 related_posts:
   - /donts-of-processes-for-upward-communication/
+  - donts-of-processes-for-upward-communication
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-format-obsession.md
+++ b/_garden/upward-comms-format-obsession.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
 related_posts:
   - /donts-of-processes-for-upward-communication/
+  - donts-of-processes-for-upward-communication
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-no-engineer-buy-in.md
+++ b/_garden/upward-comms-no-engineer-buy-in.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
 related_posts:
   - /donts-of-processes-for-upward-communication/
+  - donts-of-processes-for-upward-communication
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-unresponsiveness.md
+++ b/_garden/upward-comms-unresponsiveness.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
 related_posts:
   - /donts-of-processes-for-upward-communication/
+  - donts-of-processes-for-upward-communication
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-communication-anti-patterns.md
+++ b/_garden/upward-communication-anti-patterns.md
@@ -6,6 +6,7 @@ tags: [people-management, leadership, communication, organizational-design]
 created: 2026-04-27
 related_posts:
   - /donts-of-processes-for-upward-communication/
+  - donts-of-processes-for-upward-communication
 related_notes:
   - concern-response-framework
   - upward-comms-asymmetric-commitment

--- a/_garden/vcs-should-match-development-model.md
+++ b/_garden/vcs-should-match-development-model.md
@@ -6,6 +6,7 @@ tags: [software-engineering, version-control, development-model]
 created: 2026-04-27
 related_posts:
   - /git-may-not-be-the-best-for-saas-companies/
+  - git-may-not-be-the-best-for-saas-companies
 related_notes:
   - git-conflicts-with-trunk-based-saas
   - survival-vs-excellence-modes

--- a/scripts/lint-pkm.sh
+++ b/scripts/lint-pkm.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# lint-pkm.sh — Validate PKM notes for completeness
+#
+# Checks:
+#   1. Wikilink completeness (orphan + cross-reference)
+#   2. Missing wikilink detection (advisory)
+#   3. published_in validation against garden files
+#   4. connects_to format / dangling reference check
+#
+# Exit 0 if no errors (warnings OK), exit 1 if any errors.
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+NOTES_DIR="brain/notes"
+GARDEN_DIR=""
+FILES=()
+SHOW_HELP=0
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+usage() {
+    cat <<'EOF'
+Usage: lint-pkm.sh [OPTIONS] [FILE ...]
+
+Lint PKM notes for completeness. When no files are given, lints every
+note matching brain/notes/note-*.md.
+
+Options:
+  --garden-dir DIR   Path to the digital-garden directory
+                     (auto-detected if omitted)
+  --help             Show this help and exit
+
+Examples:
+  ./brain/scripts/lint-pkm.sh
+  ./brain/scripts/lint-pkm.sh brain/notes/note-20260424-confabulation-is-plausible.md
+  ./brain/scripts/lint-pkm.sh --garden-dir ~/workspace/srikanthsastry.github.io/_garden/
+EOF
+    exit 0
+}
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --garden-dir)
+            GARDEN_DIR="$2"; shift 2 ;;
+        --help|-h)
+            usage ;;
+        *)
+            FILES+=("$1"); shift ;;
+    esac
+done
+
+# ── Resolve workspace root ───────────────────────────────────────────────────
+# The script can be invoked from anywhere; anchor relative paths to the
+# directory that contains brain/.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# brain/scripts → go up two levels to workspace root
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$WORKSPACE_ROOT"
+
+# ── Auto-detect garden dir ────────────────────────────────────────────────────
+if [[ -z "$GARDEN_DIR" ]]; then
+    for candidate in \
+        "$WORKSPACE_ROOT/srikanthsastry.github.io/_garden" \
+        "$HOME/workspace/srikanthsastry.github.io/_garden" \
+        "$WORKSPACE_ROOT/brain/../srikanthsastry.github.io/_garden"; do
+        if [[ -d "$candidate" ]]; then
+            GARDEN_DIR="$candidate"
+            break
+        fi
+    done
+fi
+
+# ── Collect target files ─────────────────────────────────────────────────────
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    mapfile -t FILES < <(find "$NOTES_DIR" -maxdepth 1 -name 'note-*.md' -type f | sort)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "No PKM notes found to lint."
+    exit 0
+fi
+
+# ── Helper functions ──────────────────────────────────────────────────────────
+
+# Extract a single-line frontmatter value
+get_fm() {
+    local file="$1" key="$2"
+    sed -n '/^---$/,/^---$/p' "$file" | grep -m1 "^${key}:" | sed "s/^${key}:[[:space:]]*//" || true
+}
+
+# Extract a multi-line YAML list (returns one item per line, stripped)
+get_fm_list() {
+    local file="$1" key="$2"
+    sed -n '/^---$/,/^---$/p' "$file" | awk -v key="$key:" '
+        $0 ~ "^"key {found=1; next}
+        found && /^[[:space:]]*- / {gsub(/^[[:space:]]*- /, ""); print; next}
+        found && /^[a-zA-Z]/ {exit}
+    '
+}
+
+# Extract body text (everything after the second ---)
+get_body() {
+    local file="$1"
+    awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file"
+}
+
+# note-20260424-directive-gap.md → directive-gap
+make_slug() {
+    local basename="$1"
+    local slug="${basename%.md}"
+    # Strip prefixes: note- / thought- / source- / src-
+    slug=$(echo "$slug" | sed -E 's/^(thought|note|source|src)-//')
+    # Strip date prefixes: YYYYMMDD- or YYYY-MM-DD-
+    slug=$(echo "$slug" | sed -E 's/^[0-9]{8}-//' | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//')
+    echo "$slug"
+}
+
+# ── Build slug index ──────────────────────────────────────────────────────────
+# Map: slug → full filename (relative path)
+declare -A SLUG_TO_FILE
+declare -A ALL_SLUGS   # just for quick existence check
+mapfile -t ALL_NOTE_FILES < <(find "$NOTES_DIR" -maxdepth 1 -name 'note-*.md' -type f | sort)
+
+for f in "${ALL_NOTE_FILES[@]}"; do
+    bname="$(basename "$f")"
+    s="$(make_slug "$bname")"
+    SLUG_TO_FILE["$s"]="$f"
+    ALL_SLUGS["$s"]=1
+done
+
+# ── Accumulators ──────────────────────────────────────────────────────────────
+declare -A FILE_ERRORS   # file → newline-separated error strings
+declare -A FILE_WARNINGS # file → newline-separated warning strings
+TOTAL_ERRORS=0
+TOTAL_WARNINGS=0
+
+add_error() {
+    local file="$1" msg="$2"
+    if [[ -n "${FILE_ERRORS[$file]+x}" ]]; then
+        FILE_ERRORS["$file"]+=$'\n'"$msg"
+    else
+        FILE_ERRORS["$file"]="$msg"
+    fi
+    (( TOTAL_ERRORS++ )) || true
+}
+
+add_warning() {
+    local file="$1" msg="$2"
+    if [[ -n "${FILE_WARNINGS[$file]+x}" ]]; then
+        FILE_WARNINGS["$file"]+=$'\n'"$msg"
+    else
+        FILE_WARNINGS["$file"]="$msg"
+    fi
+    (( TOTAL_WARNINGS++ )) || true
+}
+
+# ── Lint each file ────────────────────────────────────────────────────────────
+for filepath in "${FILES[@]}"; do
+    if [[ ! -f "$filepath" ]]; then
+        add_error "$filepath" "[FILE_NOT_FOUND] $filepath does not exist"
+        continue
+    fi
+
+    bname="$(basename "$filepath")"
+    my_slug="$(make_slug "$bname")"
+    body="$(get_body "$filepath")"
+
+    # ── Gather frontmatter lists ──────────────────────────────────────────
+    mapfile -t connects_to_raw < <(get_fm_list "$filepath" "connects_to")
+    mapfile -t related_raw    < <(get_fm_list "$filepath" "related")
+    mapfile -t published_in_raw < <(get_fm_list "$filepath" "published_in")
+
+    # Build sets of slugs referenced in connects_to and related
+    declare -A ct_slugs=()
+    declare -A ct_paths=()
+    for entry in "${connects_to_raw[@]}"; do
+        [[ -z "$entry" ]] && continue
+        ct_paths["$entry"]=1
+        # Extract slug from path like brain/notes/note-20260424-directive-gap.md
+        entry_bname="$(basename "$entry")"
+        entry_slug="$(make_slug "$entry_bname")"
+        ct_slugs["$entry_slug"]=1
+    done
+
+    declare -A rel_slugs=()
+    for entry in "${related_raw[@]}"; do
+        [[ -z "$entry" ]] && continue
+        entry_bname="$(basename "$entry")"
+        entry_slug="$(make_slug "$entry_bname")"
+        rel_slugs["$entry_slug"]=1
+    done
+
+    # ── Check 1: Wikilink completeness ────────────────────────────────────
+    # Extract all wikilinks from body: [[slug]] or [[slug|display text]]
+    mapfile -t wikilinks < <(echo "$body" | grep -oP '\[\[([^\]|]+)' | sed 's/^\[\[//' | sort -u)
+
+    for wl_slug in "${wikilinks[@]}"; do
+        [[ -z "$wl_slug" ]] && continue
+        # Trim whitespace
+        wl_slug="$(echo "$wl_slug" | xargs)"
+
+        # Orphan check: does a note with this slug exist?
+        if [[ -z "${ALL_SLUGS[$wl_slug]+x}" ]]; then
+            add_error "$bname" "[ORPHAN_WIKILINK] [[$wl_slug]] references no existing note"
+        fi
+
+        # Cross-reference check: is this slug in connects_to or related?
+        if [[ -z "${ct_slugs[$wl_slug]+x}" ]] && [[ -z "${rel_slugs[$wl_slug]+x}" ]]; then
+            add_error "$bname" "[MISSING_CONNECTS_TO] [[$wl_slug]] in body but not in connects_to or related"
+        fi
+    done
+
+    # ── Check 4: connects_to dangling references ──────────────────────────
+    for ct_path in "${connects_to_raw[@]}"; do
+        [[ -z "$ct_path" ]] && continue
+        if [[ ! -f "$ct_path" ]]; then
+            add_error "$bname" "[DANGLING_CONNECTS_TO] connects_to entry '$ct_path' does not exist"
+        fi
+    done
+
+    # ── Check 3: published_in validation ──────────────────────────────────
+    if [[ -n "$GARDEN_DIR" ]]; then
+        garden_file="$GARDEN_DIR/${my_slug}.md"
+        if [[ -f "$garden_file" ]]; then
+            # Garden file exists — PKM should have published_in
+            # Extract related_posts from garden file
+            mapfile -t garden_related_posts < <(get_fm_list "$garden_file" "related_posts")
+
+            if [[ ${#garden_related_posts[@]} -gt 0 ]] && [[ -n "${garden_related_posts[0]}" ]]; then
+                # Garden has related_posts — check published_in
+                if [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
+                    # Build a readable list of related_posts
+                    rp_display=""
+                    for rp in "${garden_related_posts[@]}"; do
+                        [[ -z "$rp" ]] && continue
+                        if [[ -n "$rp_display" ]]; then
+                            rp_display+=", $rp"
+                        else
+                            rp_display="$rp"
+                        fi
+                    done
+                    add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists with related_posts [$rp_display] but no published_in in PKM"
+                else
+                    # Both exist — check for mismatches
+                    declare -A pi_set=()
+                    for pi in "${published_in_raw[@]}"; do
+                        [[ -z "$pi" ]] && continue
+                        pi_set["$pi"]=1
+                    done
+                    for rp in "${garden_related_posts[@]}"; do
+                        [[ -z "$rp" ]] && continue
+                        if [[ -z "${pi_set[$rp]+x}" ]]; then
+                            add_error "$bname" "[PUBLISHED_IN_MISMATCH] garden related_posts has '$rp' but PKM published_in does not"
+                        fi
+                    done
+                    unset pi_set
+                fi
+            elif [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
+                # Garden exists but no related_posts — still flag missing published_in
+                add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists at ${garden_file} but no published_in in PKM"
+            fi
+        fi
+    fi
+
+    # ── Check 2: Missing wikilink detection (advisory) ────────────────────
+    # Convert body to lowercase for case-insensitive matching
+    body_lower="$(echo "$body" | tr '[:upper:]' '[:lower:]')"
+
+    for candidate_slug in "${!ALL_SLUGS[@]}"; do
+        # Skip self
+        [[ "$candidate_slug" == "$my_slug" ]] && continue
+
+        # Skip if already wikilinked
+        already_linked=0
+        for wl in "${wikilinks[@]}"; do
+            if [[ "$wl" == "$candidate_slug" ]]; then
+                already_linked=1
+                break
+            fi
+        done
+        [[ "$already_linked" -eq 1 ]] && continue
+
+        # Convert slug kebab-case to space-separated words
+        phrase="$(echo "$candidate_slug" | tr '-' ' ')"
+
+        # Only flag if the full phrase appears as a word-boundary match
+        # Use grep -w for word boundaries, but multi-word phrases need \b
+        if echo "$body_lower" | grep -qiP "\b\Q${phrase}\E\b" 2>/dev/null; then
+            add_warning "$bname" "[POTENTIAL_WIKILINK] body mentions \"$phrase\" which matches note slug '$candidate_slug' but is not wikilinked"
+        fi
+    done
+
+    # Clean up associative arrays for next iteration
+    unset ct_slugs ct_paths rel_slugs
+done
+
+# ── Report ────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== PKM Lint Report ==="
+echo ""
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+    echo "ERRORS (must fix before garden sync):"
+    for file in $(echo "${!FILE_ERRORS[@]}" | tr ' ' '\n' | sort); do
+        echo "  $file:"
+        while IFS= read -r line; do
+            echo "    - $line"
+        done <<< "${FILE_ERRORS[$file]}"
+    done
+    echo ""
+fi
+
+if [[ $TOTAL_WARNINGS -gt 0 ]]; then
+    echo "WARNINGS (advisory):"
+    for file in $(echo "${!FILE_WARNINGS[@]}" | tr ' ' '\n' | sort); do
+        echo "  $file:"
+        while IFS= read -r line; do
+            echo "    - $line"
+        done <<< "${FILE_WARNINGS[$file]}"
+    done
+    echo ""
+fi
+
+if [[ $TOTAL_ERRORS -eq 0 ]] && [[ $TOTAL_WARNINGS -eq 0 ]]; then
+    echo "All clear — no issues found."
+    echo ""
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Files checked: ${#FILES[@]}"
+echo "  Errors: $TOTAL_ERRORS"
+echo "  Warnings: $TOTAL_WARNINGS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 # pkm-to-garden.sh — Convert PKM files to digital garden entries
 #
+# The garden is a pure derivation from PKM. This script never preserves
+# or merges data from an existing garden file. Instead, when --force is
+# used, a pre-sync guard compares the would-be output against the
+# existing garden file and refuses to overwrite if any data would be lost.
+#
 # Usage:
 #   ./scripts/pkm-to-garden.sh [--force] <pkm-file> [<pkm-file> ...]
 #
@@ -28,7 +33,7 @@ for arg in "$@"; do
             echo "Convert PKM files to digital garden entries in _garden/"
             echo ""
             echo "Options:"
-            echo "  --force    Overwrite existing garden files"
+            echo "  --force    Overwrite existing garden files (with safety guard)"
             echo "  --help     Show this help"
             echo ""
             echo "Examples:"
@@ -185,16 +190,27 @@ first_sentence() {
         }' | head -1
 }
 
-# Convert wikilinks [[slug]] to markdown links [Title](/garden/slug/)
+# Convert wikilinks to markdown links
+# [[slug|display text]] → [display text](/garden/slug/)
+# [[slug]]              → [slug](/garden/slug/)
 convert_wikilinks() {
     local text="$1"
-    echo "$text" | sed -E 's/\[\[([^]]+)\]\]/[\1](\/garden\/\1\/)/g'
+    # Normalize full-ID wikilinks: [[note-YYYYMMDD-slug]] → [[slug]]
+    text=$(echo "$text" | sed -E 's/\[\[(note|thought|source|src)-[0-9]{8}-([^]|]+)\]\]/[[\2]]/g')
+    # Also normalize full-ID with pipe: [[note-YYYYMMDD-slug|text]] → [[slug|text]]
+    text=$(echo "$text" | sed -E 's/\[\[(note|thought|source|src)-[0-9]{8}-([^]|]+)\|([^]]+)\]\]/[[\2|\3]]/g')
+    # Handle pipe syntax [[slug|display text]]
+    text=$(echo "$text" | sed -E 's/\[\[([^]|]+)\|([^]]+)\]\]/[\2](\/garden\/\1\/)/g')
+    # Handle plain [[slug]]
+    text=$(echo "$text" | sed -E 's/\[\[([^]]+)\]\]/[\1](\/garden\/\1\/)/g')
+    echo "$text"
 }
 
 # ── Main conversion loop ─────────────────────────────────────────
 
 created_count=0
 skipped_count=0
+blocked_count=0
 error_count=0
 
 for pkm_file in "${FILES[@]}"; do
@@ -255,11 +271,19 @@ for pkm_file in "${FILES[@]}"; do
     # Created date: prefer 'created', fallback to 'date_added'
     created="${pkm_created:-$pkm_date_added}"
 
-    # Related notes: collect from connects_to, related, source, inspired_by
+    # ── Collect related_notes and related_posts ──
+
     related_notes=()
     related_posts=()
 
-    # Process 'connects_to' (multi-line list)
+    # 1. Read published_in from PKM → related_posts (permalink format)
+    while IFS= read -r pi; do
+        [ -z "$pi" ] && continue
+        pi=$(echo "$pi" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        related_posts+=("$pi")
+    done < <(get_fm_list "$pkm_file" "published_in")
+
+    # 2. Process 'connects_to' (multi-line list)
     while IFS= read -r ref; do
         [ -z "$ref" ] && continue
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -271,7 +295,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     done < <(get_fm_list "$pkm_file" "connects_to")
 
-    # Process 'related' (inline array or multi-line list)
+    # 3. Process 'related' (inline array or multi-line list)
     pkm_related=$(get_fm "$pkm_file" "related")
     if [ -n "$pkm_related" ]; then
         if [[ "$pkm_related" == \[* ]]; then
@@ -298,7 +322,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     done < <(get_fm_list "$pkm_file" "related")
 
-    # Process 'source' (single value — reference to the source/draft that inspired this thought)
+    # 4. Process 'source' (single value)
     if [ -n "$pkm_source" ]; then
         resolved=$(ref_to_slug "$pkm_source")
         if [[ "$resolved" == PUBLISHED:* ]]; then
@@ -308,7 +332,7 @@ for pkm_file in "${FILES[@]}"; do
         fi
     fi
 
-    # Process 'inspired_by' (single value or inline array)
+    # 5. Process 'inspired_by' (single value, inline array, or multi-line list)
     if [ -n "$pkm_inspired_by" ]; then
         if [[ "$pkm_inspired_by" == \[* ]]; then
             while IFS= read -r ref; do
@@ -329,20 +353,167 @@ for pkm_file in "${FILES[@]}"; do
             fi
         fi
     fi
+    # Also check multi-line inspired_by list
+    while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        resolved=$(ref_to_slug "$ref")
+        if [[ "$resolved" == PUBLISHED:* ]]; then
+            related_posts+=("${resolved#PUBLISHED:}")
+        else
+            related_notes+=("$resolved")
+        fi
+    done < <(get_fm_list "$pkm_file" "inspired_by")
 
-    # Deduplicate related_notes
+    # ── Deduplicate related_notes ──
+
     if [ ${#related_notes[@]} -gt 0 ]; then
         mapfile -t related_notes < <(printf '%s\n' "${related_notes[@]}" | sort -u)
+    fi
+
+    # ── Validate related_notes: only keep slugs that exist in _garden/ ──
+
+    validated_notes=()
+    for rn in "${related_notes[@]}"; do
+        if [ -f "$GARDEN_DIR/${rn}.md" ]; then
+            validated_notes+=("$rn")
+        else
+            echo "   ⚠  Dropping related_note '$rn' (no garden file exists)"
+        fi
+    done
+    related_notes=("${validated_notes[@]+"${validated_notes[@]}"}")
+
+    # ── Deduplicate related_posts ──
+
+    if [ ${#related_posts[@]} -gt 0 ]; then
+        mapfile -t related_posts < <(printf '%s\n' "${related_posts[@]}" | sort -u)
+    fi
+
+    # ── Gate: garden notes require at least one linked post ──
+
+    if [ ${#related_posts[@]} -eq 0 ]; then
+        echo "⏭  Skipping $slug (no related_posts — garden notes require at least one linked post)"
+        skipped_count=$((skipped_count + 1))
+        continue
     fi
 
     # ── Extract and process body ──
 
     body=$(get_body "$pkm_file")
-    # Convert wikilinks
+    # Convert wikilinks (including pipe syntax)
     body=$(convert_wikilinks "$body")
 
     # Extract excerpt (first sentence of body, stripped of markdown)
     excerpt=$(first_sentence "$body")
+
+    # ── Pre-sync guard: refuse if --force would lose data ──
+
+    if [ "$FORCE" = true ] && [ -f "$garden_file" ]; then
+        losses=()
+
+        # (a) Inline link loss: /garden/ links in existing body not present in would-be body
+        existing_body=$(get_body "$garden_file")
+        existing_inline_slugs=()
+        while IFS= read -r link_slug; do
+            [ -z "$link_slug" ] && continue
+            existing_inline_slugs+=("$link_slug")
+        done < <(echo "$existing_body" | grep -oE '\(/garden/[^)]+/\)' | sed -E 's|^\(/garden/||;s|/\)$||' | sort -u)
+
+        missing_inline=()
+        for es in "${existing_inline_slugs[@]+"${existing_inline_slugs[@]}"}"; do
+            if ! echo "$body" | grep -qF "/garden/${es}/"; then
+                missing_inline+=("$es")
+            fi
+        done
+
+        # (b) related_notes loss
+        existing_rnotes=()
+        while IFS= read -r ern; do
+            [ -z "$ern" ] && continue
+            ern=$(echo "$ern" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            existing_rnotes+=("$ern")
+        done < <(get_fm_list "$garden_file" "related_notes")
+
+        missing_rnotes=()
+        for ern in "${existing_rnotes[@]+"${existing_rnotes[@]}"}"; do
+            found=false
+            for rn in "${related_notes[@]+"${related_notes[@]}"}"; do
+                if [ "$rn" = "$ern" ]; then
+                    found=true
+                    break
+                fi
+            done
+            if [ "$found" = false ]; then
+                missing_rnotes+=("$ern")
+            fi
+        done
+
+        # (c) related_posts loss
+        existing_rposts=()
+        while IFS= read -r erp; do
+            [ -z "$erp" ] && continue
+            erp=$(echo "$erp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            existing_rposts+=("$erp")
+        done < <(get_fm_list "$garden_file" "related_posts")
+
+        missing_rposts=()
+        for erp in "${existing_rposts[@]+"${existing_rposts[@]}"}"; do
+            found=false
+            for rp in "${related_posts[@]+"${related_posts[@]}"}"; do
+                if [ "$rp" = "$erp" ]; then
+                    found=true
+                    break
+                fi
+            done
+            if [ "$found" = false ]; then
+                missing_rposts+=("$erp")
+            fi
+        done
+
+        # Report losses and block if any
+        has_loss=false
+
+        if [ ${#missing_inline[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+        if [ ${#missing_rnotes[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+        if [ ${#missing_rposts[@]} -gt 0 ]; then
+            has_loss=true
+        fi
+
+        if [ "$has_loss" = true ]; then
+            echo "🛑 $slug: would lose data on --force"
+            if [ ${#missing_inline[@]} -gt 0 ]; then
+                inline_display=""
+                for mi in "${missing_inline[@]}"; do
+                    [ -n "$inline_display" ] && inline_display+=", "
+                    inline_display+="[[$mi]]"
+                done
+                echo "   Missing inline links in PKM body: $inline_display"
+            fi
+            if [ ${#missing_rnotes[@]} -gt 0 ]; then
+                rnotes_display=""
+                for mr in "${missing_rnotes[@]}"; do
+                    [ -n "$rnotes_display" ] && rnotes_display+=", "
+                    rnotes_display+="$mr"
+                done
+                echo "   Missing connects_to in PKM: $rnotes_display"
+            fi
+            if [ ${#missing_rposts[@]} -gt 0 ]; then
+                rposts_display=""
+                for mp in "${missing_rposts[@]}"; do
+                    [ -n "$rposts_display" ] && rposts_display+=", "
+                    rposts_display+="$mp"
+                done
+                echo "   Missing published_in in PKM: $rposts_display"
+            fi
+            echo "   Fix the PKM note first, then re-run."
+            blocked_count=$((blocked_count + 1))
+            continue
+        fi
+    fi
 
     # ── Write garden file ──
 
@@ -358,8 +529,11 @@ for pkm_file in "${FILES[@]}"; do
             echo "created: $created"
         fi
 
-        # Related posts (empty by default — user fills in permalinks)
-        echo "related_posts: []"
+        # Related posts
+        echo "related_posts:"
+        for rp in "${related_posts[@]}"; do
+            echo "  - $rp"
+        done
 
         # Related notes
         if [ ${#related_notes[@]} -gt 0 ]; then
@@ -397,6 +571,7 @@ done
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Created: $created_count"
+echo "  Blocked: $blocked_count"
 echo "  Skipped: $skipped_count"
 echo "  Errors:  $error_count"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -405,7 +580,7 @@ if [ $created_count -gt 0 ]; then
     echo "Next steps:"
     echo "  1. Review generated files in _garden/"
     echo "  2. Adjust titles, maturity levels, and excerpt_text"
-    echo "  3. Add blog post permalinks to related_posts"
+    echo "  3. Add published_in permalinks to PKM notes for related_posts"
     echo "  4. Add related_notes slugs for connected garden entries"
-    echo "  5. Add inline links from your blog post to these garden notes"
+    echo "  5. Add inline wikilinks in PKM body for garden cross-references"
 fi


### PR DESCRIPTION
All garden notes re-derived purely from PKM sources.

Depends on #110 (tooling update) — that commit is cherry-picked onto this branch.

## What changed
- 77 garden notes regenerated from PKM via `pkm-to-garden.sh --force`
- `published_in` in PKM → `related_posts` in garden
- Wikilinks in PKM bodies → inline `/garden/` links in garden bodies
- Pre-sync guard validated: zero blocked files

## How to review
Compare any garden file against its PKM source in `brain/notes/` to verify pure derivation.