### PR TITLE
Garden tooling fixes: PUBLISHED skip, permalink validation, multi-line tags, drop garden_type

### DIFF
--- a/scripts/lint-pkm.sh
+++ b/scripts/lint-pkm.sh
@@ -6,6 +6,7 @@
 #   2. Missing wikilink detection (advisory)
 #   3. published_in validation against garden files
 #   4. connects_to format / dangling reference check
+#   5. published_in entries point to actual published posts
 #
 # Exit 0 if no errors (warnings OK), exit 1 if any errors.
 
@@ -69,6 +70,15 @@ if [[ -z "$GARDEN_DIR" ]]; then
             break
         fi
     done
+fi
+
+# ── Auto-detect posts dir (for published_in validation) ──────────────────────
+POSTS_DIR=""
+if [[ -n "$GARDEN_DIR" ]]; then
+    candidate="$(cd "$(dirname "$GARDEN_DIR")" && pwd)/_posts"
+    if [[ -d "$candidate" ]]; then
+        POSTS_DIR="$candidate"
+    fi
 fi
 
 # ── Collect target files ─────────────────────────────────────────────────────
@@ -261,6 +271,18 @@ for filepath in "${FILES[@]}"; do
                 add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists at ${garden_file} but no published_in in PKM"
             fi
         fi
+    fi
+
+    # ── Check 5: published_in entries point to actual published posts ─────
+    if [[ -n "$POSTS_DIR" ]] && [[ ${#published_in_raw[@]} -gt 0 ]]; then
+        for pi in "${published_in_raw[@]}"; do
+            [[ -z "$pi" ]] && continue
+            # Strip leading/trailing slashes to get the slug
+            # Check if any post in _posts/ has this permalink in its frontmatter
+            if ! grep -rl "^permalink: ${pi}$" "$POSTS_DIR/" >/dev/null 2>&1; then
+                add_error "$bname" "[UNPUBLISHED_IN_PUBLISHED_IN] published_in '$pi' has no matching post in _posts/"
+            fi
+        done
     fi
 
     # ── Check 2: Missing wikilink detection (advisory) ────────────────────

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -53,6 +53,17 @@ fi
 
 mkdir -p "$GARDEN_DIR"
 
+# ── Build published-post permalink index ──────────────────────────
+# Scan all _posts/ files for their permalink: frontmatter values.
+# This is used to validate published_in entries.
+declare -A PUBLISHED_PERMALINKS
+while IFS= read -r pfile; do
+    plink=$(sed -n '/^---$/,/^---$/p' "$pfile" | grep -m1 '^permalink:' | sed 's/^permalink:[[:space:]]*//' || true)
+    if [ -n "$plink" ]; then
+        PUBLISHED_PERMALINKS["$plink"]=1
+    fi
+done < <(find "$REPO_DIR/_posts" -name '*.md' -type f 2>/dev/null)
+
 # ── Helper functions ──────────────────────────────────────────────
 
 # Extract a YAML frontmatter value by key (first match, single-line values only)
@@ -289,10 +300,16 @@ for pkm_file in "${FILES[@]}"; do
     related_posts=()
 
     # 1. Read published_in from PKM → related_posts (permalink format)
+    #    Validate each permalink against actual published posts in _posts/
     while IFS= read -r pi; do
         [ -z "$pi" ] && continue
         pi=$(echo "$pi" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        related_posts+=("$pi")
+        # Validate against the published-post permalink index
+        if [[ -n "${PUBLISHED_PERMALINKS[$pi]+x}" ]]; then
+            related_posts+=("$pi")
+        else
+            echo "   ⚠  Skipping published_in '$pi' (no published post found in _posts/)"
+        fi
     done < <(get_fm_list "$pkm_file" "published_in")
 
     # 2. Process 'connects_to' (multi-line list)
@@ -537,7 +554,7 @@ for pkm_file in "${FILES[@]}"; do
     {
         echo "---"
         echo "title: \"$title\""
-        echo "garden_type: $pkm_type"
+
         echo "maturity: $maturity"
         if [ -n "$tags_line" ]; then
             echo "tags: $tags_line"


### PR DESCRIPTION
Fixes to pkm-to-garden.sh and lint-pkm.sh that missed PR #110 (pushed after merge).

- Skip PUBLISHED refs from connects_to/inspired_by for related_posts (published_in is canonical)
- Fix continue → no-op so source/inspired_by PUBLISHED refs don't skip entire notes
- Validate published_in entries against actual _posts/ permalink frontmatter
- Handle multi-line YAML tags in PKM notes  
- Remove garden_type field from output (always 'note', no information)
- Lint: add UNPUBLISHED_IN_PUBLISHED_IN check