### PR TITLE
Add governance series navigation to all articles

### DIFF
--- a/_includes/governance_series_nav.html
+++ b/_includes/governance_series_nav.html
@@ -1,0 +1,4 @@
+<aside class="series-nav" style="background: #f8f6f3; border-left: 3px solid #8B4513; padding: 0.75em 1em; margin: 1.5em 0; font-size: 0.9em;">
+<strong>Series: Directive Governance</strong><br>
+<a href="/cargo-cult-governance/">Cargo Cult Governance</a> · <a href="/directive-governance-situationship/">The Situationship</a> · <a href="/deliverance-from-directive-governance/">Deliverance</a> · <a href="/subsidiarity-is-not-hayek/">Subsidiarity is not Hayek</a>
+</aside>

--- a/_includes/governance_series_nav.html
+++ b/_includes/governance_series_nav.html
@@ -1,4 +1,4 @@
 <aside class="series-nav" style="background: #f8f6f3; border-left: 3px solid #8B4513; padding: 0.75em 1em; margin: 1.5em 0; font-size: 0.9em;">
 <strong>Series: Directive Governance</strong><br>
-<a href="/cargo-cult-governance/">Cargo Cult Governance</a> · <a href="/directive-governance-situationship/">The Situationship</a> · <a href="/deliverance-from-directive-governance/">Deliverance</a> · <a href="/subsidiarity-is-not-hayek/">Subsidiarity is not Hayek</a>
+<a href="/cargo-cult-governance/">Cargo Cult Governance</a> · <a href="/directive-governance-situationship/">The Situationship</a> · <a href="/deliverance-from-directive-governance/">Deliverance</a>
 </aside>

--- a/_posts/2026-03-26-cargo-cult-governance.md
+++ b/_posts/2026-03-26-cargo-cult-governance.md
@@ -18,6 +18,8 @@ excerpt: >
     assumptions that directive governance depends on: compression, proxy validity, and separability: all fail in software.
 ---
 
+{% include governance_series_nav.html %}
+
 In the tech industry, we have been through a corporate rollercoaster in the last few years. First, it was the hiring mania during COVID, followed by widespread layoffs starting 2023. Then there is the pivot at AI, followed by the "flattening" of middle management. Regardless of whether you were laid off, or you carry the survivor's guilt, or you are shoveling AI slop to get to something useful, the mental scars are very real. So is the cynicism that the leadership may not know what it is doing. The decisions feel callous, short-sighted, even whimsical, and based on [wildly inaccurate information](/garden/data-pipeline-is-achilles-heel/).
 
 But does it *have* to work this way? What's actually driving these decisions, and is there a better mechanism? Because if the answer is "this is just how large companies work," that's one kind of problem. If the answer is "there's a specific, diagnosable flaw in how these decisions get made", then that's a different one. One that might be fixable.

--- a/_posts/2026-04-16-directive-governance-situationship.md
+++ b/_posts/2026-04-16-directive-governance-situationship.md
@@ -15,6 +15,8 @@ excerpt: >
     Directive (top-down) governance is structurally wrong for software engineering. So why do tech companies persist with it? The answer is a ratchet: companies centralize quickly during crisis and decentralize very slowly afterward. Three compounding layers make this asymmetry sticky.
 ---
 
+{% include governance_series_nav.html %}
+
 
 Most large tech companies operate top-down. Information flows up through a reporting chain. Decisions are made centrally. Directives flow back down. This is true regardless of what their culture decks say. Unfortunately, it is the wrong way to govern for software engineering. Top-down governance works when information flowing upstream is compressible, the metrics that decision makers see are a good proxy for org health and success, and decision-making and execution are distinct from each other. None of these hold for software engineering. I have detailed all the wrongness in ["Cargo Cult Governance".](https://srikanth.sastry.name/cargo-cult-governance/)
 

--- a/_posts/2026-05-02-deliverance-from-directive-governance.md
+++ b/_posts/2026-05-02-deliverance-from-directive-governance.md
@@ -16,6 +16,8 @@ excerpt: >
     Directive governance is structurally wrong for software and a structural ratchet keeps it in place. The escape is subsidiarity, decisions made at the lowest competent level, sustained by missionary culture that resists re-centralization under pressure.
 ---
 
+{% include governance_series_nav.html %}
+
 
 This is the third post in the series about [directive governance](/garden/directive-governance/). The [first post](/cargo-cult-governance/) diagnosed the problem with governance in the tech industry as directive governance applied where it doesn't belong. Directive governance is top-down governance: decisions flow down, information travels up. It works in Pharma and manufacturing because three [preconditions](/garden/directive-governance-preconditions/) hold. (1) Information can be compressed without losing signal. (2) Metrics are good proxies for what the organization cares about. And (3) execution is distinct from decision-making. [None of this holds](/garden/essential-complexity-makes-software-ungovernable/) for software.
 


### PR DESCRIPTION
Adds a shared `_includes/governance_series_nav.html` with a compact series bar:

> **Series: Directive Governance**
> Cargo Cult Governance · The Situationship · Deliverance · Subsidiarity is not Hayek

Included at the top of all three published articles. The `subsidiarity-is-not-hayek` draft (PR #108) will pick this up when it merges main.

Single source of truth — one include, four posts.