### PR TITLE
Add unit testing series navigation to all posts

### DIFF
--- a/_includes/unit_testing_series_nav.html
+++ b/_includes/unit_testing_series_nav.html
@@ -1,0 +1,27 @@
+<aside class="series-nav" style="background: #f8f6f3; border-left: 3px solid #2e6da4; padding: 0.75em 1em; margin: 1.5em 0; font-size: 0.85em; line-height: 1.6;">
+<strong>Series: Unit Testing</strong>
+<div style="margin-top: 0.4em;">
+<span style="color: #666; font-weight: 600;">Merits:</span>
+<a href="/merits-of-unit-tests-part-1/">Why Unit Test?</a> ·
+<a href="/the-merits-of-unit-tests-part-2/">Part 2</a> ·
+<a href="/the-merits-of-unit-tests-part-3/">Part 3</a> ·
+<a href="/unit-tests-ftw-part-4/">Part 4</a> ·
+<a href="/merits-of-unit-tests-part-5/">Part 5</a>
+</div>
+<div style="margin-top: 0.3em;">
+<span style="color: #666; font-weight: 600;">Practices:</span>
+<a href="/the-big-why-about-unit-tests/">The Big Why</a> ·
+<a href="/unit-test-attributes-and-their-trade-offs/">Attributes &amp; Tradeoffs</a> ·
+<a href="/defining-unit-tests-two-schools-of-thought/">Two Schools</a> ·
+<a href="/in-unit-tests-favor-detroit-over-london/">Detroit over London</a> ·
+<a href="/unit-test-the-brains-and-not-the-nerves/">Brains Not Nerves</a> ·
+<a href="/dry-unit-tests-are-bad/">DRY Tests</a> ·
+<a href="/tests-should-be-isolated-not-coupled/">Coupled Tests</a> ·
+<a href="/mocks-stubs-andhow-to-use-them/">Mocks &amp; Stubs</a> ·
+<a href="/privatize-your-classes-for-better-unit-testing/">Privatize Classes</a> ·
+<a href="/law-of-demeter-and-unit-tests/">Law of Demeter</a> ·
+<a href="/beware-of-using-patch-object-to-test-your-python-code/">patch.object</a> ·
+<a href="/do-not-index-in-test-coverage/">Coverage Metrics</a> ·
+<a href="/tdd-for-bug-fixes/">TDD for Bug Fixes</a>
+</div>
+</aside>

--- a/_posts/2017-11-01-merits-of-unit-tests-part-1.md
+++ b/_posts/2017-11-01-merits-of-unit-tests-part-1.md
@@ -13,6 +13,7 @@ tags:
     - 'software testing'
     - 'unit test'
 ---
+{% include unit_testing_series_nav.html %}
 
 There are multiple reasons to write unit tests. Verification is only one of them, and the least interesting. This is part 1 of a five part series on why you should write unit tests (apart from the obvious): Documentation!
 

--- a/_posts/2017-11-12-the-merits-of-unit-tests-part-2.md
+++ b/_posts/2017-11-12-the-merits-of-unit-tests-part-2.md
@@ -12,6 +12,7 @@ tags:
     - 'software testing'
     - 'unit test'
 ---
+{% include unit_testing_series_nav.html %}
 
 In the [previous post](http://srikanth.sastry.name/merits-of-unit-tests-part-1/),  we saw how unit tests can serve as a reliable source of documentation  for your code. There is a lot more that unit tests can do for you. In this post I'll talk about a fairly obvious, but often ignored, benefit  to unit testing: Refactoring.
 

--- a/_posts/2017-11-22-the-merits-of-unit-tests-part-3.md
+++ b/_posts/2017-11-22-the-merits-of-unit-tests-part-3.md
@@ -11,6 +11,7 @@ tags:
     - 'software engineering'
     - 'software testing'
 ---
+{% include unit_testing_series_nav.html %}
 
 Cross posted on [LinkedIn](https://www.linkedin.com/pulse/merits-unit-tests-part-3-srikanth-sastry/).
 

--- a/_posts/2017-11-28-unit-tests-ftw-part-4.md
+++ b/_posts/2017-11-28-unit-tests-ftw-part-4.md
@@ -11,6 +11,7 @@ tags:
     - 'software engineering'
     - 'software testing'
 ---
+{% include unit_testing_series_nav.html %}
 
 Cross posted on [LinkedIn](https://www.linkedin.com/pulse/unit-tests-ftw-part-4-srikanth-sastry/)
 

--- a/_posts/2017-12-28-merits-of-unit-tests-part-5.md
+++ b/_posts/2017-12-28-merits-of-unit-tests-part-5.md
@@ -11,6 +11,7 @@ tags:
     - 'software engineering'
     - 'software testing'
 ---
+{% include unit_testing_series_nav.html %}
 
 Cross posted on [LinkedIn](https://www.linkedin.com/pulse/merits-unit-tests-part-5-srikanth-sastry/).
 

--- a/_posts/2022-02-28-beware-of-using-patch-object-to-test-your-python-code.md
+++ b/_posts/2022-02-28-beware-of-using-patch-object-to-test-your-python-code.md
@@ -16,6 +16,7 @@ excerpt: >
   In fact, this can make your tests untrustworthy and become a maintenance headache with failures every time you extended your base class.
 image: /assets/images/software-testing.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![Software Testing](/assets/images/software-testing.jpg) -->
 
 [Liskov substitution principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle) states that a class and its subclass must be interchangeable without breaking the program. Unfortunately, Python's [`patch.object`](https://docs.python.org/3/library/unittest.mock.html#patch-object) breaks this principle in a big way. In fact, **this can make your tests untrustworthy and become a maintenance headache with failures every time you extended your base class**. Here is a contrived, but concrete example.

--- a/_posts/2022-04-29-do-not-index-on-test-coverage.md
+++ b/_posts/2022-04-29-do-not-index-on-test-coverage.md
@@ -16,6 +16,7 @@ excerpt: >
   The temptation, therefore, is to measure everything. Even the quality of your unit tests, and there where the trouble usually begins. <a href="/garden/coverage-metrics-are-misleading/">Coverage metrics are misleading</a>. For an detailed explanation of why indexing on the test coverage metrics is a bad idea, I highly recommend Jason Rudolph's collection of posts on this topic (https://jasonrudolph.com/blog/testing-anti-patterns-how-to-fail-with-100-test-coverage/). To drive home the point more explicitly (and motivate you to actually go read Jason's posts), here are some illustrative explanations.
 image: /assets/images/chart-coverage.png
 ...
+{% include unit_testing_series_nav.html %}
 
 <!-- ![Coverage Chart](/assets/images/chart-coverage.png) -->
 

--- a/_posts/2022-05-17-DRY-unit-tests-are-bad.md
+++ b/_posts/2022-05-17-DRY-unit-tests-are-bad.md
@@ -13,6 +13,7 @@ excerpt: >
   Simplicity should be a core property of unit tests. This is motivated, both by arguments in this post against DRY unit tests, and by software maintainability as the primary motivation for unit tests. Unit tests should be as simple as reasonable. It should be easy to ready, understand, and modify (it should be easy to modify any single test in isolation). It is perfectly acceptable for this simplicity to come at the expense of code-reuse, performance, and efficiency.
 image: /assets/images/squeeze-cloth.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![DRY](/assets/images/squeeze-cloth.jpg) -->
 
 ["Don't Repeat Yourself" (DRY)](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) is arguably one of the most important principles in software engineering. It is considered a truism among many. A consequence of such dogmatic allegiance to DRYness is that we see a lot of DRY unit tests; this is where the utility of the DRY principle breaks down — <a href="/garden/simplicity-over-dry-in-tests/">simplicity matters more than DRY in tests</a>.

--- a/_posts/2022-05-25-mocks-stubs-and-how-to-use-them.md
+++ b/_posts/2022-05-25-mocks-stubs-and-how-to-use-them.md
@@ -20,6 +20,7 @@ permalink: /mocks-stubs-andhow-to-use-them/
 layout: post
 image: /assets/images/masquerade-masks.png
 ---
+{% include unit_testing_series_nav.html %}
 
 <!-- ![Photo by Polina Kovaleva from Pexels](/assets/images/masquerade-masks.png) -->
 _Photo by [Polina Kovaleva](https://www.pexels.com/@polina-kovaleva?utm_content=attributionCopyText&utm_medium=referral&utm_source=pexels) from [Pexels](https://www.pexels.com/photo/close-up-of-masquerade-masks-on-purple-background-8404608/?utm_content=attributionCopyText&utm_medium=referral&utm_source=pexels)_

--- a/_posts/2022-05-31-unit-test-brains-and-not-nerves.md
+++ b/_posts/2022-05-31-unit-test-brains-and-not-nerves.md
@@ -18,6 +18,7 @@ excerpt: >
   Unit tests most benefit the most complex parts of your codebase that often requires the most technical skill and domain knowledge to author, read, and maintain. Integration tests disproportionately benefit the parts of your codebase that communicate with external dependencies.
 image: /assets/images/brain-magnifying-glass.png
 ...
+{% include unit_testing_series_nav.html %}
 _Note: This is inspired from the book "[Unit Testing: Principles, Practices, and Patterns](https://www.manning.com/books/unit-testing)" by Vladimir Khorikov._
 
 <!-- ![brain](/assets/images/brain-magnifying-glass.png) -->

--- a/_posts/2022-06-06-the-big-why-about-unit-tests.md
+++ b/_posts/2022-06-06-the-big-why-about-unit-tests.md
@@ -14,6 +14,7 @@ excerpt: >
   The ultimate "why" for unit tests is maintainability. All the arguments for having robust, good quality unit tests comes down to the following. Unit tests help keep your production code maintainable. Looking at maintainability as the primary motivation for unit tests allows us to look at some aspects of unit tests differently.
 image: /assets/images/question_mark_person_leaning.png
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![Why unit test?](/assets/images/question_mark_person_leaning.png) -->
 When you ask "why do we write need unit tests?", you will get several answers including
 - To find common bugs in your code

--- a/_posts/2022-06-13-unit-test-attributes-and-their-trade-offs.md
+++ b/_posts/2022-06-13-unit-test-attributes-and-their-trade-offs.md
@@ -15,6 +15,7 @@ excerpt: >
   So how do you choose what to maximize?
 image: /assets/images/accuracy-completeness-speed.png
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![](/assets/images/accuracy-completeness-speed.png) -->
 Unit test suites have <a href="/garden/unit-test-attribute-tradeoffs/">three primary attributes</a>.
 

--- a/_posts/2022-06-18-defining-unit-tests-two-schools-of-thought.md
+++ b/_posts/2022-06-18-defining-unit-tests-two-schools-of-thought.md
@@ -17,6 +17,7 @@ excerpt: >
   There are two schools of thought on the notion of "unit" and "isolation", and that makes all the difference.
 image: /assets/images/london-detroit.jpg
 ...
+{% include unit_testing_series_nav.html %}
 
 <!-- ![](/assets/images/london-detroit.jpg) -->
 

--- a/_posts/2022-06-26-in-unit-tests-i-favor-detroit-over-london.md
+++ b/_posts/2022-06-26-in-unit-tests-i-favor-detroit-over-london.md
@@ -15,6 +15,7 @@ layout: post
 permalink: /in-unit-tests-favor-detroit-over-london/
 image: /assets/images/detroit-wall-frame.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![](/assets/images/detroit-wall-frame.jpg) -->
 
 [Recall]({%post_url 2022-06-18-defining-unit-tests-two-schools-of-thought %}) the two schools of thought around unit test: Detroit, and London. Briefly, the Detroit school considers a 'unit' of software to be tested as a 'behavior' that consists of one or more classes, and unit tests replace only shared and/or external dependencies with test doubles. In contrast, the London school consider a 'unit' to be a single class, and replaces all dependencies with test doubles. 

--- a/_posts/2022-07-03-coupled-tests.md
+++ b/_posts/2022-07-03-coupled-tests.md
@@ -11,6 +11,7 @@ layout: post
 permalink: /tests-should-be-isolated-not-coupled/
 image: /assets/images/carabiners-connected.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![](/assets/images/carabiners-connected.jpg) -->
 Almost [by definition]({% post_url 2022-06-18-defining-unit-tests-two-schools-of-thought %}) unit tests should be _isolated_ from its (external, shared) dependencies. But, equally importantly, unit tests should also be isolated _from each other_. When one test starts to affect another test, the two tests are said to be <a href="/garden/coupled-tests/"><em>coupled</em></a>. Alternatively, if changes to one test _can_ negatively impact the correctness of another test, then the two tests are said to be _coupled_.
 

--- a/_posts/2022-07-11-privatize-your-classes-for-better-unit-testing.md
+++ b/_posts/2022-07-11-privatize-your-classes-for-better-unit-testing.md
@@ -12,6 +12,7 @@ layout: post
 permalink: /privatize-your-classes-for-better-unit-testing/
 image: /assets/images/amber-iceberg-under-water.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![](images/amber-iceberg-under-water.jpg) -->
 You service may be massive, but it's public API surface is pretty small; it has just a handful of APIs/endpoints. Everything else behind those APIs are 'private' and 'implementation details'. It is highly advisable to follow this pattern even when designing the implementation of your service, almost like a fractal. This will pay dividends in the quality of your test suite.
 

--- a/_posts/2022-07-22-the-law-of-demeter-and-unit-tests.md
+++ b/_posts/2022-07-22-the-law-of-demeter-and-unit-tests.md
@@ -11,6 +11,7 @@ layout: post
 permalink: /law-of-demeter-and-unit-tests/
 image: /assets/images/demeter-sketch-bw.jpg
 ...
+{% include unit_testing_series_nav.html %}
 <!-- ![](/assets/images/demeter-sketch-bw.jpg) -->
 The [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) essentially says that each unit should only talk to its 'immediate friends' or 'immediate dependencies', and in spirit, it is pointing to the principle that each unit only have the information it needs to meet its purpose. In that spirit, the Law of Demeter takes two forms that are relevant to <a href="/garden/law-of-demeter-and-testing/">making your code more testable</a>: (1) object chains, and (2) fat parameters.
 

--- a/_posts/2025-06-11-tdd-for-bug-fixes.md
+++ b/_posts/2025-06-11-tdd-for-bug-fixes.md
@@ -12,6 +12,7 @@ tags:
 permalink: /tdd-for-bug-fixes/
 image: /assets/images/bug-stabbing-software-engineer-in-the-back.png
 ...
+{% include unit_testing_series_nav.html %}
 
 <!-- ![](/assets/images/bug-stabbing-software-engineer-in-the-back.png) -->
 


### PR DESCRIPTION
Adds a two-section series navigation bar to all 18 unit testing posts:

**Merits (2017):** 5 posts — Why Unit Test? through Part 5
**Practices (2022-2025):** 13 posts — The Big Why through TDD for Bug Fixes

The nav bar uses the same `<aside class="series-nav">` pattern as the governance series, with:
- Blue accent (`#2e6da4`) to distinguish from the governance series (brown)
- Two labeled sections (Merits / Practices) to keep 18 links scannable
- Short labels for each post
- Responsive: wraps naturally on mobile

**Files:**
- `_includes/unit_testing_series_nav.html` — new include
- 18 posts modified — include added after frontmatter closing delimiter