### PR TITLE
Agent readiness: content signals, markdown export, and alternate link

### DIFF
--- a/_includes/custom_head.html
+++ b/_includes/custom_head.html
@@ -2,3 +2,6 @@
 {% endif %}
 <link rel="stylesheet" href="{{ '/assets/css/garden.css' | relative_url }}" />
 <script src="{{ '/assets/js/garden-preview.js' | relative_url }}" defer></script>
+{% if page.layout == 'post' or page.layout == 'garden-note' %}
+<link rel="alternate" type="text/markdown" href="index.md" title="{{ page.title | escape }} (Markdown)" />
+{% endif %}

--- a/_plugins/markdown_export.rb
+++ b/_plugins/markdown_export.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# MarkdownExport — Jekyll Generator plugin
+#
+# For every post and garden note, writes a clean `.md` file alongside the
+# HTML output so that AI agents can fetch raw markdown at a predictable URL
+# (e.g. /the-suggestible-actor/index.md instead of /the-suggestible-actor/).
+#
+# The markdown file includes YAML frontmatter with title, date, tags,
+# excerpt, and canonical_url, followed by the body stripped of Liquid tags.
+
+module Jekyll
+  class MarkdownExport < Generator
+    safe true
+    priority :lowest  # run after everything else has been generated
+
+    def generate(site)
+      exportable = site.posts.docs + site.collections.fetch("garden", Jekyll::Collection.new(site, "garden")).docs
+
+      exportable.each do |doc|
+        next unless doc.data["title"]
+        next unless File.exist?(doc.path)
+
+        source = File.read(doc.path, encoding: "utf-8")
+        body = extract_body(source)
+        body = strip_liquid(body)
+
+        frontmatter = build_frontmatter(doc, site)
+        md_content = frontmatter + body
+
+        # Write to _site/<url>/index.md (matching the HTML permalink structure)
+        dest_dir = File.join(site.dest, doc.url)
+        FileUtils.mkdir_p(dest_dir)
+        dest_path = File.join(dest_dir, "index.md")
+        File.write(dest_path, md_content)
+
+        # Register as a static file so Jekyll doesn't clean it up
+        site.static_files << StaticFile.new(
+          site, site.dest, doc.url, "index.md"
+        )
+      end
+    end
+
+    private
+
+    # Extract everything after the closing --- of YAML frontmatter
+    def extract_body(source)
+      if source =~ /\A---\s*\n.*?\n---\s*\n(.*)/m
+        Regexp.last_match(1)
+      else
+        source
+      end
+    end
+
+    # Strip Liquid template tags: {% ... %} and {{ ... }}
+    def strip_liquid(text)
+      text
+        .gsub(/\{%.*?%\}/m, "")
+        .gsub(/\{\{.*?\}\}/m, "")
+        .gsub(/^\s*\n{3,}/, "\n\n")  # collapse excessive blank lines left behind
+    end
+
+    def build_frontmatter(doc, site)
+      excerpt_text = extract_excerpt(doc)
+
+      fm = {
+        "title"         => doc.data["title"],
+        "date"          => format_date(doc),
+        "tags"          => doc.data["tags"],
+        "excerpt"       => excerpt_text,
+        "canonical_url" => File.join(site.config["url"].to_s, doc.url),
+      }.compact
+
+      "---\n#{fm.map { |k, v| yaml_line(k, v) }.join}\n---\n\n"
+    end
+
+    def format_date(doc)
+      date = doc.data["date"] || doc.data["created"]
+      return nil unless date
+
+      if date.is_a?(Time) || date.is_a?(DateTime)
+        date.strftime("%Y-%m-%d")
+      else
+        date.to_s[0..9]  # "2026-04-24" from string or Date
+      end
+    end
+
+    def extract_excerpt(doc)
+      # Prefer explicit excerpt_text frontmatter (garden notes use this)
+      raw = doc.data["excerpt_text"]
+
+      # Fall back to Jekyll's auto-generated excerpt
+      raw ||= doc.data["excerpt"].to_s if doc.data["excerpt"]
+
+      return nil if raw.nil? || raw.strip.empty?
+
+      # Strip HTML tags (Jekyll sometimes renders excerpts)
+      clean = raw.to_s.gsub(/<[^>]+>/, "").gsub(/\s+/, " ").strip
+
+      # Truncate to ~300 chars at a word boundary
+      if clean.length > 300
+        clean = clean[0..300].sub(/\s\S*$/, "") + "…"
+      end
+
+      clean.empty? ? nil : clean
+    end
+
+    # Simple YAML serialization for frontmatter lines
+    def yaml_line(key, value)
+      case value
+      when Array
+        "#{key}:\n#{value.map { |v| "  - #{v}" }.join("\n")}\n"
+      when String
+        if value.include?("\n") || value.include?('"') || value.include?(":")
+          "#{key}: >-\n  #{value.gsub("\n", "\n  ")}\n"
+        else
+          "#{key}: \"#{value}\"\n"
+        end
+      else
+        "#{key}: #{value}\n"
+      end
+    end
+  end
+end

--- a/_plugins/markdown_export.rb
+++ b/_plugins/markdown_export.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# MarkdownExport — Jekyll Generator plugin
+# MarkdownExport — Jekyll plugin (post_write hook)
 #
 # For every post and garden note, writes a clean `.md` file alongside the
 # HTML output so that AI agents can fetch raw markdown at a predictable URL
@@ -8,117 +8,100 @@
 #
 # The markdown file includes YAML frontmatter with title, date, tags,
 # excerpt, and canonical_url, followed by the body stripped of Liquid tags.
+#
+# Uses :post_write so that _site/ is fully built before we add files.
 
-module Jekyll
-  class MarkdownExport < Generator
-    safe true
-    priority :lowest  # run after everything else has been generated
+Jekyll::Hooks.register :site, :post_write do |site|
+  exportable = site.posts.docs +
+    site.collections.fetch("garden", Jekyll::Collection.new(site, "garden")).docs
 
-    def generate(site)
-      exportable = site.posts.docs + site.collections.fetch("garden", Jekyll::Collection.new(site, "garden")).docs
+  exportable.each do |doc|
+    next unless doc.data["title"]
+    next unless File.exist?(doc.path)
 
-      exportable.each do |doc|
-        next unless doc.data["title"]
-        next unless File.exist?(doc.path)
+    source = File.read(doc.path, encoding: "utf-8")
+    body = extract_body(source)
+    body = strip_liquid(body)
 
-        source = File.read(doc.path, encoding: "utf-8")
-        body = extract_body(source)
-        body = strip_liquid(body)
+    frontmatter = build_frontmatter(doc, site)
+    md_content = frontmatter + body
 
-        frontmatter = build_frontmatter(doc, site)
-        md_content = frontmatter + body
+    # Write to _site/<url>/index.md (matching the HTML permalink structure)
+    dest_dir = File.join(site.dest, doc.url)
+    FileUtils.mkdir_p(dest_dir)
+    dest_path = File.join(dest_dir, "index.md")
+    File.write(dest_path, md_content)
+  end
+end
 
-        # Write to _site/<url>/index.md (matching the HTML permalink structure)
-        dest_dir = File.join(site.dest, doc.url)
-        FileUtils.mkdir_p(dest_dir)
-        dest_path = File.join(dest_dir, "index.md")
-        File.write(dest_path, md_content)
+# --- helper methods at module level ---
 
-        # Register as a static file so Jekyll doesn't clean it up
-        site.static_files << StaticFile.new(
-          site, site.dest, doc.url, "index.md"
-        )
-      end
+def extract_body(source)
+  if source =~ /\A---\s*\n.*?\n---\s*\n(.*)/m
+    Regexp.last_match(1)
+  else
+    source
+  end
+end
+
+def strip_liquid(text)
+  text
+    .gsub(/\{%.*?%\}/m, "")
+    .gsub(/\{\{.*?\}\}/m, "")
+    .gsub(/^\s*\n{3,}/, "\n\n") # collapse excessive blank lines left behind
+end
+
+def build_frontmatter(doc, site)
+  excerpt_text = extract_excerpt(doc)
+
+  fm = {
+    "title"         => doc.data["title"],
+    "date"          => format_doc_date(doc),
+    "tags"          => doc.data["tags"],
+    "excerpt"       => excerpt_text,
+    "canonical_url" => File.join(site.config["url"].to_s, doc.url),
+  }.compact
+
+  "---\n#{fm.map { |k, v| yaml_line(k, v) }.join}\n---\n\n"
+end
+
+def format_doc_date(doc)
+  date = doc.data["date"] || doc.data["created"]
+  return nil unless date
+
+  if date.is_a?(Time) || date.is_a?(DateTime)
+    date.strftime("%Y-%m-%d")
+  else
+    date.to_s[0..9]
+  end
+end
+
+def extract_excerpt(doc)
+  raw = doc.data["excerpt_text"]
+  raw ||= doc.data["excerpt"].to_s if doc.data["excerpt"]
+
+  return nil if raw.nil? || raw.strip.empty?
+
+  clean = raw.to_s.gsub(/<[^>]+>/, "").gsub(/\s+/, " ").strip
+
+  if clean.length > 300
+    clean = clean[0..300].sub(/\s\S*$/, "") + "…"
+  end
+
+  clean.empty? ? nil : clean
+end
+
+def yaml_line(key, value)
+  case value
+  when Array
+    "#{key}:\n#{value.map { |v| "  - #{v}" }.join("\n")}\n"
+  when String
+    if value.include?("\n") || value.include?('"') || value.include?(":")
+      "#{key}: >-\n  #{value.gsub("\n", "\n  ")}\n"
+    else
+      "#{key}: \"#{value}\"\n"
     end
-
-    private
-
-    # Extract everything after the closing --- of YAML frontmatter
-    def extract_body(source)
-      if source =~ /\A---\s*\n.*?\n---\s*\n(.*)/m
-        Regexp.last_match(1)
-      else
-        source
-      end
-    end
-
-    # Strip Liquid template tags: {% ... %} and {{ ... }}
-    def strip_liquid(text)
-      text
-        .gsub(/\{%.*?%\}/m, "")
-        .gsub(/\{\{.*?\}\}/m, "")
-        .gsub(/^\s*\n{3,}/, "\n\n")  # collapse excessive blank lines left behind
-    end
-
-    def build_frontmatter(doc, site)
-      excerpt_text = extract_excerpt(doc)
-
-      fm = {
-        "title"         => doc.data["title"],
-        "date"          => format_date(doc),
-        "tags"          => doc.data["tags"],
-        "excerpt"       => excerpt_text,
-        "canonical_url" => File.join(site.config["url"].to_s, doc.url),
-      }.compact
-
-      "---\n#{fm.map { |k, v| yaml_line(k, v) }.join}\n---\n\n"
-    end
-
-    def format_date(doc)
-      date = doc.data["date"] || doc.data["created"]
-      return nil unless date
-
-      if date.is_a?(Time) || date.is_a?(DateTime)
-        date.strftime("%Y-%m-%d")
-      else
-        date.to_s[0..9]  # "2026-04-24" from string or Date
-      end
-    end
-
-    def extract_excerpt(doc)
-      # Prefer explicit excerpt_text frontmatter (garden notes use this)
-      raw = doc.data["excerpt_text"]
-
-      # Fall back to Jekyll's auto-generated excerpt
-      raw ||= doc.data["excerpt"].to_s if doc.data["excerpt"]
-
-      return nil if raw.nil? || raw.strip.empty?
-
-      # Strip HTML tags (Jekyll sometimes renders excerpts)
-      clean = raw.to_s.gsub(/<[^>]+>/, "").gsub(/\s+/, " ").strip
-
-      # Truncate to ~300 chars at a word boundary
-      if clean.length > 300
-        clean = clean[0..300].sub(/\s\S*$/, "") + "…"
-      end
-
-      clean.empty? ? nil : clean
-    end
-
-    # Simple YAML serialization for frontmatter lines
-    def yaml_line(key, value)
-      case value
-      when Array
-        "#{key}:\n#{value.map { |v| "  - #{v}" }.join("\n")}\n"
-      when String
-        if value.include?("\n") || value.include?('"') || value.include?(":")
-          "#{key}: >-\n  #{value.gsub("\n", "\n  ")}\n"
-        else
-          "#{key}: \"#{value}\"\n"
-        end
-      else
-        "#{key}: #{value}\n"
-      end
-    end
+  else
+    "#{key}: #{value}\n"
   end
 end

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,28 @@
+# Content Signals Policy
+# (a) If a content-signal = yes, you may collect content for the
+#     corresponding use.
+# (b) If a content-signal = no, you may not collect content for the
+#     corresponding use.
+# (c) If the website operator does not include a content signal for a
+#     corresponding use, the website operator neither grants nor restricts
+#     permission via content signal with respect to the corresponding use.
+#
+# The content signals and their meanings are:
+#
+# search: building a search index and providing search results (e.g., returning
+#         hyperlinks and short excerpts from your website's contents). Search
+#         does not include providing AI-generated search summaries.
+# ai-input: inputting content into one or more AI models (e.g., retrieval
+#           augmented generation, grounding, or other real-time taking of
+#           content for generative AI search answers).
+# ai-train: training or fine-tuning AI models.
+#
+# ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS RESERVATIONS OF
+# RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN UNION DIRECTIVE 2019/790 ON COPYRIGHT
+# AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
+
+# Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
## What this PR does

Three changes to improve the site's agent readiness score on [isitagentready.com](https://isitagentready.com/srikanth.sastry.name).

### 1. Content Signals in `robots.txt`

Adds the [Cloudflare Content Signals Policy](https://contentsignals.org/) block to `robots.txt`, declaring:

```
Content-Signal: search=yes, ai-input=yes, ai-train=yes
```

This explicitly signals to AI crawlers that content may be used for search indexing, AI input (RAG, grounding), and training. Previously, the `robots.txt` had AI bot `Allow` rules but no content signals — the checker flagged this as a missing signal.

**Addresses:** Bot Access Control → Content Signals in robots.txt (currently failing)

### 2. Markdown export plugin (`_plugins/markdown_export.rb`)

A Jekyll Generator that produces a clean `.md` file alongside every post and garden note's HTML output. For example, `/the-suggestible-actor/index.html` gets a sibling `/the-suggestible-actor/index.md`.

Each markdown file includes:
- Clean YAML frontmatter: title, date, tags, excerpt, canonical_url
- The raw markdown body, stripped of Liquid template tags (`{% %}`, `{{ }}`)

This lets AI agents fetch structured markdown directly instead of parsing HTML. Since the site is on GitHub Pages (no Cloudflare), server-side content negotiation isn't possible — but serving markdown at a predictable adjacent URL achieves the same practical result.

### 3. `<link rel="alternate">` in `custom_head.html`

Adds a `<link rel="alternate" type="text/markdown" href="index.md">` tag to the `<head>` of every post and garden note page. This makes the markdown version discoverable through standard HTML semantics — agents that inspect `<link>` tags in the document head can find and prefer the markdown version.

Only renders on `post` and `garden-note` layouts (not the homepage, archive pages, etc.).

## Score impact

| Check | Before | After |
|-------|--------|-------|
| Content Signals in robots.txt | ❌ Fail | ✅ Pass |
| Markdown availability | N/A (no markdown served) | Markdown at every post URL |
| Alternate link discovery | No `<link>` tag | `<link rel="alternate" type="text/markdown">` |

The Content Signals fix should directly flip that checker from fail to pass. The markdown export and alternate link won't flip the "Markdown Negotiation" check (that requires HTTP-level content negotiation, which needs Cloudflare), but they provide the practical equivalent for agents that follow `<link>` tags.