### PR TITLE
Remove related_posts from garden notes — use computed backlinks only

### DIFF
--- a/_garden/ai-agent-category-error.md
+++ b/_garden/ai-agent-category-error.md
@@ -3,8 +3,6 @@ title: "The AI Agent Category Error"
 maturity: evergreen
 tags: [ai, software-design, actor-models, category-error]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - friction-requires-intent
   - goal-vs-intent

--- a/_garden/align-alerts-to-sev-criteria.md
+++ b/_garden/align-alerts-to-sev-criteria.md
@@ -3,8 +3,6 @@ title: "Align Alerts to SEV Criteria"
 maturity: evergreen
 tags: [operations, alerting, monitoring, SLOs, on-call]
 created: 2026-04-27
-related_posts:
-  - /sync-your-alerts-to-your-sev-criteria/
 related_notes: []
 excerpt_text: >
   Alerts should fire at or near the threshold where an SLO breach would occur, not well before.

--- a/_garden/ambient-to-local.md
+++ b/_garden/ambient-to-local.md
@@ -3,8 +3,6 @@ title: "Convert Ambient Knowledge into Local Context"
 maturity: evergreen
 tags: [ai, software-design, prescriptions]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - confabulation-is-plausible
   - directive-gap

--- a/_garden/backward-compatibility-for-leaky-abstractions.md
+++ b/_garden/backward-compatibility-for-leaky-abstractions.md
@@ -3,8 +3,6 @@ title: "Backward Compatibility for Leaky Abstractions"
 maturity: evergreen
 tags: [software-engineering, backward-compatibility, leaky-abstractions, defensive-programming]
 created: 2026-04-27
-related_posts:
-  - /backward-compatibility-where-you-dont-expect/
 related_notes: []
 excerpt_text: >
   When a framework leaks implementation details (like serializing arguments at schedule time but loading code from HEAD at execution time), changing a function signature breaks the assumption that old code calls old signatures.

--- a/_garden/check-if-concern-is-systemic.md
+++ b/_garden/check-if-concern-is-systemic.md
@@ -3,8 +3,6 @@ title: "Check If Concern Is Systemic"
 maturity: evergreen
 tags: [people-management, leadership, communication]
 created: 2026-04-27
-related_posts:
-  - /responding-to-concerns-as-a-people-manager/
 related_notes:
   - concern-response-framework
 excerpt_text: >

--- a/_garden/command-control-misnomer.md
+++ b/_garden/command-control-misnomer.md
@@ -3,8 +3,6 @@ title: "Command Control Misnomer"
 maturity: evergreen
 tags: [governance, directive-governance, terminology, military]
 created: 2026-04-27
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - directive-governance
 excerpt_text: >

--- a/_garden/concern-response-framework.md
+++ b/_garden/concern-response-framework.md
@@ -3,8 +3,6 @@ title: "Listen Before Solving Concerns"
 maturity: evergreen
 tags: [people-management, leadership, communication]
 created: 2026-04-27
-related_posts:
-  - /responding-to-concerns-as-a-people-manager/
 related_notes:
   - check-if-concern-is-systemic
   - explaining-away-concerns-is-victim-blaming

--- a/_garden/confabulation-is-plausible.md
+++ b/_garden/confabulation-is-plausible.md
@@ -3,8 +3,6 @@ title: "Confabulation Is Plausible"
 maturity: budding
 tags: [ai, failure-modes, hallucination]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ambient-to-local
   - directive-gap

--- a/_garden/coupled-tests.md
+++ b/_garden/coupled-tests.md
@@ -3,8 +3,6 @@ title: "Coupled Tests"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design, anti-patterns]
 created: 2026-04-27
-related_posts:
-  - /tests-should-be-isolated-not-coupled/
 related_notes:
   - simplicity-over-dry-in-tests
   - unit-test-attribute-tradeoffs

--- a/_garden/coverage-metrics-are-misleading.md
+++ b/_garden/coverage-metrics-are-misleading.md
@@ -3,8 +3,6 @@ title: "Coverage Metrics Are Misleading"
 maturity: evergreen
 tags: [software-testing, unit-tests, metrics, test-coverage]
 created: 2026-04-27
-related_posts:
-  - /do-not-index-in-test-coverage/
 related_notes:
   - testability-drives-design
   - tests-as-executable-documentation

--- a/_garden/crisis-centralization-ratchet.md
+++ b/_garden/crisis-centralization-ratchet.md
@@ -3,10 +3,6 @@ title: "Crisis Centralization Ratchet"
 maturity: budding
 tags: [governance, centralization, crisis, tech-industry, wartime-ceo]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
-  - /subsidiarity-is-not-hayek/
-  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - serial-satisficing-without-learning

--- a/_garden/data-pipeline-is-achilles-heel.md
+++ b/_garden/data-pipeline-is-achilles-heel.md
@@ -3,8 +3,6 @@ title: "Data Pipeline Is Achilles Heel"
 maturity: budding
 tags: [governance, bounded-rationality, information-asymmetry, data-quality]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - metrics-measure-maintenance-not-creation
   - serial-satisficing-without-learning

--- a/_garden/defense-in-depth-needs-visibility.md
+++ b/_garden/defense-in-depth-needs-visibility.md
@@ -3,8 +3,6 @@ title: "Defense in Depth Needs Visibility"
 maturity: evergreen
 tags: [software-engineering, defense-in-depth, monitoring, operations]
 created: 2026-04-27
-related_posts:
-  - /defense-in-depth-vs-locality-of-behavior/
 related_notes:
   - align-alerts-to-sev-criteria
 excerpt_text: >

--- a/_garden/delegation-mimicry-without-cultural-substrate.md
+++ b/_garden/delegation-mimicry-without-cultural-substrate.md
@@ -3,10 +3,6 @@ title: "Delegation Mimicry Without Cultural Substrate"
 maturity: budding
 tags: [governance, directive-governance, delegation, cultural-substrate, isomorphism]
 created: 2026-04-26
-related_posts:
-  - /cargo-cult-governance/
-  - /subsidiarity-is-not-hayek/
-  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - isomorphic-mimicry-in-tech-governance

--- a/_garden/detroit-school-testing.md
+++ b/_garden/detroit-school-testing.md
@@ -3,9 +3,6 @@ title: "The Detroit School of Unit Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design, detroit-school]
 created: 2026-04-27
-related_posts:
-  - /defining-unit-tests-two-schools-of-thought/
-  - /in-unit-tests-favor-detroit-over-london/
 related_notes:
   - detroit-vs-london-testing
   - london-school-testing

--- a/_garden/detroit-vs-london-testing.md
+++ b/_garden/detroit-vs-london-testing.md
@@ -3,9 +3,6 @@ title: "Detroit vs. London Schools of Unit Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design, detroit-school, london-school]
 created: 2026-04-27
-related_posts:
-  - /defining-unit-tests-two-schools-of-thought/
-  - /in-unit-tests-favor-detroit-over-london/
 related_notes:
   - detroit-school-testing
   - london-school-testing

--- a/_garden/directive-gap.md
+++ b/_garden/directive-gap.md
@@ -3,8 +3,6 @@ title: "The Directive Gap"
 maturity: evergreen
 tags: [ai, software-design, failure-modes]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ambient-to-local
   - confabulation-is-plausible

--- a/_garden/directive-governance-cargo-cult.md
+++ b/_garden/directive-governance-cargo-cult.md
@@ -3,8 +3,6 @@ title: "Directive Governance Cargo Cult"
 maturity: budding
 tags: [governance, directive-governance, mechanistic-organization, cargo-cult]
 created: 2026-04-27
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - directive-governance
   - isomorphic-mimicry-in-tech-governance

--- a/_garden/directive-governance-degrades-not-destroys.md
+++ b/_garden/directive-governance-degrades-not-destroys.md
@@ -3,8 +3,6 @@ title: "Directive Governance Degrades Not Destroys"
 maturity: budding
 tags: [governance, directive-governance, monopoly-rents, rebuttal]
 created: 2026-04-26
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - isomorphic-mimicry-in-tech-governance
   - serial-satisficing-without-learning

--- a/_garden/directive-governance-is-not-keynesian.md
+++ b/_garden/directive-governance-is-not-keynesian.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, directive-governance, keynes, organizational-theory]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - directive-governance
   - directive-governance-preconditions

--- a/_garden/directive-governance-preconditions.md
+++ b/_garden/directive-governance-preconditions.md
@@ -3,10 +3,6 @@ title: "Directive Governance Preconditions"
 maturity: budding
 tags: [governance, directive-governance, preconditions]
 created: 2026-04-27
-related_posts:
-  - /directive-governance-situationship/
-  - /subsidiarity-is-not-hayek/
-  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - essential-complexity-makes-software-ungovernable

--- a/_garden/directive-governance.md
+++ b/_garden/directive-governance.md
@@ -3,10 +3,6 @@ title: "Directive Governance"
 maturity: evergreen
 tags: [governance, directive-governance, mechanistic-organization, organizational-theory, decision-making]
 created: 2026-04-27
-related_posts:
-  - /directive-governance-situationship/
-  - /subsidiarity-is-not-hayek/
-  - /deliverance-from-directive-governance/
 related_notes:
   - command-control-misnomer
   - data-pipeline-is-achilles-heel

--- a/_garden/essential-complexity-makes-software-ungovernable.md
+++ b/_garden/essential-complexity-makes-software-ungovernable.md
@@ -3,9 +3,6 @@ title: "Essential Complexity Makes Software Ungovernable"
 maturity: evergreen
 tags: [governance, software-engineering, brooks, essential-complexity]
 created: 2026-04-25
-related_posts:
-  - /cargo-cult-governance/
-  - /deliverance-from-directive-governance/
 related_notes:
   - in-software-execution-is-decision-making
   - isomorphic-mimicry-in-tech-governance

--- a/_garden/every-mutation-needs-an-undo.md
+++ b/_garden/every-mutation-needs-an-undo.md
@@ -3,8 +3,6 @@ title: "Every Mutation Needs an Undo"
 maturity: evergreen
 tags: [operations, scripts, software-engineering, safety]
 created: 2026-04-27
-related_posts:
-  - /scripts-and-their-undo/
 related_notes: []
 excerpt_text: >
   Every script that mutates system state should build an undo alongside the forward operation.

--- a/_garden/explaining-away-concerns-is-victim-blaming.md
+++ b/_garden/explaining-away-concerns-is-victim-blaming.md
@@ -3,8 +3,6 @@ title: "Explaining Away Concerns Is Victim Blaming"
 maturity: evergreen
 tags: [people-management, leadership, communication]
 created: 2026-04-27
-related_posts:
-  - /responding-to-concerns-as-a-people-manager/
 related_notes:
   - concern-response-framework
 excerpt_text: >

--- a/_garden/failure-argument-is-conditional.md
+++ b/_garden/failure-argument-is-conditional.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, directive-governance, hayek, software-engineering]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - directive-governance-preconditions
   - essential-complexity-makes-software-ungovernable

--- a/_garden/fakes-over-stubs.md
+++ b/_garden/fakes-over-stubs.md
@@ -3,8 +3,6 @@ title: "Fakes Over Stubs"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-doubles, fakes]
 created: 2026-04-27
-related_posts:
-  - /mocks-stubs-andhow-to-use-them/
 related_notes:
   - mocks-vs-stubs
   - stubs-in-testing

--- a/_garden/friction-requires-intent.md
+++ b/_garden/friction-requires-intent.md
@@ -3,8 +3,6 @@ title: "Friction Requires Intent"
 maturity: evergreen
 tags: [software-design, ergonomics, ai, pit-of-success]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ai-agent-category-error
   - intent-spectrum

--- a/_garden/git-conflicts-with-trunk-based-saas.md
+++ b/_garden/git-conflicts-with-trunk-based-saas.md
@@ -3,8 +3,6 @@ title: "Git Conflicts with Trunk-Based SaaS Workflows"
 maturity: evergreen
 tags: [software-engineering, version-control, git, trunk-based-development]
 created: 2026-04-27
-related_posts:
-  - /git-may-not-be-the-best-for-saas-companies/
 related_notes:
   - vcs-should-match-development-model
 excerpt_text: >

--- a/_garden/goal-vs-intent.md
+++ b/_garden/goal-vs-intent.md
@@ -3,8 +3,6 @@ title: "Goal vs. Intent"
 maturity: evergreen
 tags: [ai, definitions, mental-models]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ai-agent-category-error
   - intent-spectrum

--- a/_garden/in-software-execution-is-decision-making.md
+++ b/_garden/in-software-execution-is-decision-making.md
@@ -3,8 +3,6 @@ title: "In Software Execution Is Decision Making"
 maturity: evergreen
 tags: [software-engineering, governance, brooks, essential-complexity, decision-authority]
 created: 2026-04-25
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - data-pipeline-is-achilles-heel
   - essential-complexity-makes-software-ungovernable

--- a/_garden/intent-spectrum.md
+++ b/_garden/intent-spectrum.md
@@ -3,8 +3,6 @@ title: "The Intent Spectrum"
 maturity: evergreen
 tags: [software-design, actor-models, mental-models]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ai-agent-category-error
   - friction-requires-intent

--- a/_garden/isomorphic-mimicry-in-tech-governance.md
+++ b/_garden/isomorphic-mimicry-in-tech-governance.md
@@ -3,8 +3,6 @@ title: "Isomorphic Mimicry In Tech Governance"
 maturity: budding
 tags: [governance, directive-governance, institutional-theory, isomorphism, tech-industry]
 created: 2026-04-26
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - delegation-mimicry-without-cultural-substrate
   - essential-complexity-makes-software-ungovernable

--- a/_garden/law-of-demeter-and-testing.md
+++ b/_garden/law-of-demeter-and-testing.md
@@ -3,8 +3,6 @@ title: "Law of Demeter and Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, law-of-demeter, software-design, coupling]
 created: 2026-04-27
-related_posts:
-  - /law-of-demeter-and-unit-tests/
 related_notes:
   - minimize-public-surface-for-testability
   - testability-drives-design

--- a/_garden/london-school-testing.md
+++ b/_garden/london-school-testing.md
@@ -3,9 +3,6 @@ title: "The London School of Unit Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design, london-school]
 created: 2026-04-27
-related_posts:
-  - /defining-unit-tests-two-schools-of-thought/
-  - /in-unit-tests-favor-detroit-over-london/
 related_notes:
   - detroit-school-testing
   - detroit-vs-london-testing

--- a/_garden/metrics-measure-maintenance-not-creation.md
+++ b/_garden/metrics-measure-maintenance-not-creation.md
@@ -3,8 +3,6 @@ title: "Metrics Measure Maintenance Not Creation"
 maturity: budding
 tags: [metrics, governance, innovation, qualitative-signal-loss]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - data-pipeline-is-achilles-heel
   - partial-measurement-worse-than-none

--- a/_garden/minimize-public-surface-for-testability.md
+++ b/_garden/minimize-public-surface-for-testability.md
@@ -3,8 +3,6 @@ title: "Minimize Public Surface for Testability"
 maturity: evergreen
 tags: [software-testing, unit-tests, encapsulation, software-design]
 created: 2026-04-27
-related_posts:
-  - /privatize-your-classes-for-better-unit-testing/
 related_notes:
   - test-behavior-not-implementation
   - testability-drives-design

--- a/_garden/mission-not-price-coordinates.md
+++ b/_garden/mission-not-price-coordinates.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, subsidiarity, hayek, missionary-culture]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - crisis-centralization-ratchet
   - delegation-mimicry-without-cultural-substrate

--- a/_garden/mocks-in-testing.md
+++ b/_garden/mocks-in-testing.md
@@ -3,8 +3,6 @@ title: "Mocks in Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-doubles, mocks]
 created: 2026-04-27
-related_posts:
-  - /mocks-stubs-andhow-to-use-them/
 related_notes:
   - mocks-vs-stubs
   - stubs-in-testing

--- a/_garden/mocks-vs-stubs.md
+++ b/_garden/mocks-vs-stubs.md
@@ -3,8 +3,6 @@ title: "Mocks vs. Stubs: When to Use Which"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-doubles, mocks, stubs]
 created: 2026-04-27
-related_posts:
-  - /mocks-stubs-andhow-to-use-them/
 related_notes:
   - mocks-in-testing
   - simplicity-over-dry-in-tests

--- a/_garden/never-sacrifice-test-accuracy.md
+++ b/_garden/never-sacrifice-test-accuracy.md
@@ -3,8 +3,6 @@ title: "Never Sacrifice Test Accuracy"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design, accuracy]
 created: 2026-04-27
-related_posts:
-  - /unit-test-attributes-and-their-trade-offs/
 related_notes:
   - coverage-metrics-are-misleading
   - unit-test-attribute-tradeoffs

--- a/_garden/partial-measurement-worse-than-none.md
+++ b/_garden/partial-measurement-worse-than-none.md
@@ -3,8 +3,6 @@ title: "Partial Measurement Worse Than None"
 maturity: budding
 tags: [metrics, measurement, governance, austin]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - metrics-measure-maintenance-not-creation
 excerpt_text: >

--- a/_garden/ratchet-has-no-market-analog.md
+++ b/_garden/ratchet-has-no-market-analog.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, directive-governance, crisis-centralization-ratchet, organizational-theory]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - crisis-centralization-ratchet
   - directive-governance

--- a/_garden/reduce-cyclomatic-complexity.md
+++ b/_garden/reduce-cyclomatic-complexity.md
@@ -3,8 +3,6 @@ title: "Reduce Cyclomatic Complexity"
 maturity: evergreen
 tags: [software-design, refactoring, code-quality, cyclomatic-complexity]
 created: 2026-04-27
-related_posts:
-  - /reduce-cyclomatic-complexity/
 related_notes:
   - testability-drives-design
 excerpt_text: >

--- a/_garden/reuse-code-not-objects.md
+++ b/_garden/reuse-code-not-objects.md
@@ -3,8 +3,6 @@ title: "Reuse Code, Not Objects"
 maturity: evergreen
 tags: [software-engineering, design-patterns, DRY, statefulness]
 created: 2026-04-27
-related_posts:
-  - /reuse-code-not-objects/
 related_notes: []
 excerpt_text: >
   DRY applies to code, not to object instances.

--- a/_garden/serial-satisficing-without-learning.md
+++ b/_garden/serial-satisficing-without-learning.md
@@ -3,8 +3,6 @@ title: "Serial Satisficing Without Learning"
 maturity: budding
 tags: [bounded-rationality, governance, layoffs, decision-making]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - data-pipeline-is-achilles-heel
   - unfalsifiable-organizational-corrections

--- a/_garden/shadow-verify-migrate-pattern.md
+++ b/_garden/shadow-verify-migrate-pattern.md
@@ -3,8 +3,6 @@ title: "Shadow-Verify-Migrate Pattern"
 maturity: evergreen
 tags: [software-engineering, design-patterns, migration, object-composition]
 created: 2026-04-27
-related_posts:
-  - /object-composition-for-service-migration/
 related_notes: []
 excerpt_text: >
   Migrate between service implementations in three composed steps: shadow, verify, switch.

--- a/_garden/simplicity-over-dry-in-tests.md
+++ b/_garden/simplicity-over-dry-in-tests.md
@@ -3,8 +3,6 @@ title: "Simplicity Over DRY in Tests"
 maturity: evergreen
 tags: [software-testing, unit-tests, DRY, test-design]
 created: 2026-04-27
-related_posts:
-  - /dry-unit-tests-are-bad/
 related_notes:
   - coverage-metrics-are-misleading
   - tests-as-executable-documentation

--- a/_garden/structurelessness-hides-hierarchy.md
+++ b/_garden/structurelessness-hides-hierarchy.md
@@ -3,9 +3,6 @@ title: "Structurelessness Hides Hierarchy"
 maturity: evergreen
 tags: [governance, organizational-design, hierarchy, directive-governance]
 created: 2026-04-26
-related_posts:
-  - /cargo-cult-governance/
-  - /deliverance-from-directive-governance/
 related_notes:
   - isomorphic-mimicry-in-tech-governance
   - three-assumptions-framework

--- a/_garden/stubs-in-testing.md
+++ b/_garden/stubs-in-testing.md
@@ -3,8 +3,6 @@ title: "Stubs in Testing"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-doubles, stubs]
 created: 2026-04-27
-related_posts:
-  - /mocks-stubs-andhow-to-use-them/
 related_notes:
   - fakes-over-stubs
   - mocks-in-testing

--- a/_garden/subsidiarity-is-not-flat-organization.md
+++ b/_garden/subsidiarity-is-not-flat-organization.md
@@ -3,9 +3,6 @@ title: "Subsidiarity Is Not Flat Organization"
 maturity: evergreen
 tags: [governance, subsidiarity, organizational-theory, hierarchy]
 created: 2026-04-27
-related_posts:
-  - /cargo-cult-governance/
-  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - subsidiarity

--- a/_garden/subsidiarity-is-third-position.md
+++ b/_garden/subsidiarity-is-third-position.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, subsidiarity, hayek, keynes, catholic-social-teaching]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - subsidiarity
 excerpt_text: >

--- a/_garden/subsidiarity-preserves-hierarchy.md
+++ b/_garden/subsidiarity-preserves-hierarchy.md
@@ -4,8 +4,6 @@ garden_type: note
 maturity: evergreen
 tags: [governance, subsidiarity, hayek, organizational-theory]
 created: 2026-05-01
-related_posts:
-  - /subsidiarity-is-not-hayek/
 related_notes:
   - subsidiarity
   - subsidiarity-is-not-flat-organization

--- a/_garden/subsidiarity.md
+++ b/_garden/subsidiarity.md
@@ -3,11 +3,6 @@ title: "Subsidiarity"
 maturity: evergreen
 tags: [governance, subsidiarity, organizational-theory, catholic-social-teaching, decision-making]
 created: 2026-04-27
-related_posts:
-  - /cargo-cult-governance/
-  - /directive-governance-situationship/
-  - /subsidiarity-is-not-hayek/
-  - /deliverance-from-directive-governance/
 related_notes:
   - directive-governance
   - essential-complexity-makes-software-ungovernable

--- a/_garden/suggestible-actor-properties.md
+++ b/_garden/suggestible-actor-properties.md
@@ -3,8 +3,6 @@ title: "The Suggestible Actor: Four Properties"
 maturity: evergreen
 tags: [ai, software-design, actor-models, suggestible-actor]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ai-agent-category-error
   - ambient-to-local

--- a/_garden/survival-vs-excellence-modes.md
+++ b/_garden/survival-vs-excellence-modes.md
@@ -3,9 +3,6 @@ title: "Survival vs. Excellence as Engineering Modes"
 maturity: evergreen
 tags: [software-engineering, engineering-culture, tech-debt, decision-making]
 created: 2026-04-27
-related_posts:
-  - /are-you-building-for-survival-or-excellence/
-  - /when-should-you-build-for-survival/
 related_notes: []
 excerpt_text: >
   Software development has two modes (survival and excellence), and the choice should be deliberate, not a default.

--- a/_garden/susceptibility-peaks-at-failure.md
+++ b/_garden/susceptibility-peaks-at-failure.md
@@ -3,8 +3,6 @@ title: "Susceptibility Peaks at Failure"
 maturity: budding
 tags: [ai, software-design, design-levers]
 created: 2026-04-24
-related_posts:
-  - /the-suggestible-actor/
 related_notes:
   - ambient-to-local
   - confabulation-is-plausible

--- a/_garden/tdd-for-bug-fixes.md
+++ b/_garden/tdd-for-bug-fixes.md
@@ -3,8 +3,6 @@ title: "TDD for Bug Fixes"
 maturity: evergreen
 tags: [software-testing, tdd, bug-fixing, test-driven-development]
 created: 2026-04-27
-related_posts:
-  - /tdd-for-bug-fixes/
 related_notes:
   - tests-as-executable-documentation
   - tests-for-maintainability

--- a/_garden/test-behavior-not-implementation.md
+++ b/_garden/test-behavior-not-implementation.md
@@ -3,8 +3,6 @@ title: "Test Behavior, Not Implementation"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design]
 created: 2026-04-27
-related_posts:
-  - /unit-test-the-brains-and-not-the-nerves/
 related_notes:
   - mocks-vs-stubs
   - tests-as-refactoring-safety-net

--- a/_garden/testability-drives-design.md
+++ b/_garden/testability-drives-design.md
@@ -3,8 +3,6 @@ title: "Testability Forces Modularity"
 maturity: evergreen
 tags: [software-testing, unit-tests, software-design, modularity]
 created: 2026-04-27
-related_posts:
-  - /the-merits-of-unit-tests-part-3/
 related_notes:
   - testability-forces-dependency-injection
   - tests-as-executable-documentation

--- a/_garden/testability-forces-dependency-injection.md
+++ b/_garden/testability-forces-dependency-injection.md
@@ -3,8 +3,6 @@ title: "Testability Forces Dependency Injection"
 maturity: evergreen
 tags: [software-testing, unit-tests, software-design, dependency-injection]
 created: 2026-04-27
-related_posts:
-  - /the-merits-of-unit-tests-part-3/
 related_notes:
   - testability-drives-design
   - tests-as-first-customer

--- a/_garden/tests-as-executable-documentation.md
+++ b/_garden/tests-as-executable-documentation.md
@@ -3,8 +3,6 @@ title: "Tests as Executable Documentation"
 maturity: evergreen
 tags: [software-testing, unit-tests, documentation]
 created: 2026-04-27
-related_posts:
-  - /merits-of-unit-tests-part-1/
 related_notes:
   - tests-as-first-customer
 excerpt_text: >

--- a/_garden/tests-as-first-customer.md
+++ b/_garden/tests-as-first-customer.md
@@ -3,8 +3,6 @@ title: "Tests as First Customer"
 maturity: evergreen
 tags: [software-testing, unit-tests, api-design, usability]
 created: 2026-04-27
-related_posts:
-  - /merits-of-unit-tests-part-5/
 related_notes:
   - testability-drives-design
   - tests-as-executable-documentation

--- a/_garden/tests-as-refactoring-safety-net.md
+++ b/_garden/tests-as-refactoring-safety-net.md
@@ -3,8 +3,6 @@ title: "Tests as a Refactoring Safety Net"
 maturity: evergreen
 tags: [software-testing, unit-tests, refactoring, tech-debt]
 created: 2026-04-27
-related_posts:
-  - /the-merits-of-unit-tests-part-2/
 related_notes:
   - tests-as-executable-documentation
 excerpt_text: >

--- a/_garden/tests-for-maintainability.md
+++ b/_garden/tests-for-maintainability.md
@@ -3,8 +3,6 @@ title: "Tests Exist for Maintainability"
 maturity: evergreen
 tags: [software-testing, unit-tests, software-maintenance]
 created: 2026-04-27
-related_posts:
-  - /the-big-why-about-unit-tests/
 related_notes:
   - simplicity-over-dry-in-tests
   - test-behavior-not-implementation

--- a/_garden/tests-prune-debugging-search-space.md
+++ b/_garden/tests-prune-debugging-search-space.md
@@ -3,8 +3,6 @@ title: "Tests Prune the Debugging Search Space"
 maturity: evergreen
 tags: [software-testing, unit-tests, debugging]
 created: 2026-04-27
-related_posts:
-  - /unit-tests-ftw-part-4/
 related_notes:
   - testability-drives-design
   - tests-as-refactoring-safety-net

--- a/_garden/three-assumptions-framework.md
+++ b/_garden/three-assumptions-framework.md
@@ -3,8 +3,6 @@ title: "Three Assumptions Framework"
 maturity: budding
 tags: [governance, directive-governance, information-theory, original-framework, tech-industry]
 created: 2026-04-26
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - data-pipeline-is-achilles-heel
   - directive-governance-degrades-not-destroys

--- a/_garden/tooling-advances-prove-brooks-right.md
+++ b/_garden/tooling-advances-prove-brooks-right.md
@@ -3,8 +3,6 @@ title: "Tooling Advances Prove Brooks Right"
 maturity: budding
 tags: [software-engineering, brooks, essential-complexity, tooling]
 created: 2026-04-25
-related_posts:
-  - /cargo-cult-governance/
 related_notes:
   - essential-complexity-makes-software-ungovernable
 excerpt_text: >

--- a/_garden/unfalsifiable-organizational-corrections.md
+++ b/_garden/unfalsifiable-organizational-corrections.md
@@ -3,8 +3,6 @@ title: "Unfalsifiable Organizational Corrections"
 maturity: budding
 tags: [bounded-rationality, governance, epistemology, decision-making]
 created: 2026-04-25
-related_posts:
-  - /directive-governance-situationship/
 related_notes:
   - serial-satisficing-without-learning
 excerpt_text: >

--- a/_garden/unit-test-attribute-tradeoffs.md
+++ b/_garden/unit-test-attribute-tradeoffs.md
@@ -3,8 +3,6 @@ title: "Unit Test Attribute Trilemma"
 maturity: evergreen
 tags: [software-testing, unit-tests, test-design]
 created: 2026-04-27
-related_posts:
-  - /unit-test-attributes-and-their-trade-offs/
 related_notes:
   - coverage-metrics-are-misleading
   - detroit-vs-london-testing

--- a/_garden/upward-comms-asymmetric-commitment.md
+++ b/_garden/upward-comms-asymmetric-commitment.md
@@ -3,8 +3,6 @@ title: "Upward Comms Asymmetric Commitment"
 maturity: evergreen
 tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
-related_posts:
-  - /donts-of-processes-for-upward-communication/
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-format-obsession.md
+++ b/_garden/upward-comms-format-obsession.md
@@ -3,8 +3,6 @@ title: "Upward Comms Format Obsession"
 maturity: evergreen
 tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
-related_posts:
-  - /donts-of-processes-for-upward-communication/
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-no-engineer-buy-in.md
+++ b/_garden/upward-comms-no-engineer-buy-in.md
@@ -3,8 +3,6 @@ title: "Upward Comms No Engineer Buy In"
 maturity: evergreen
 tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
-related_posts:
-  - /donts-of-processes-for-upward-communication/
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-comms-unresponsiveness.md
+++ b/_garden/upward-comms-unresponsiveness.md
@@ -3,8 +3,6 @@ title: "Upward Comms Unresponsiveness"
 maturity: evergreen
 tags: [people-management, leadership, communication, anti-pattern]
 created: 2026-04-27
-related_posts:
-  - /donts-of-processes-for-upward-communication/
 related_notes:
   - upward-communication-anti-patterns
 excerpt_text: >

--- a/_garden/upward-communication-anti-patterns.md
+++ b/_garden/upward-communication-anti-patterns.md
@@ -3,8 +3,6 @@ title: "Upward Communication Anti Patterns"
 maturity: evergreen
 tags: [people-management, leadership, communication, organizational-design]
 created: 2026-04-27
-related_posts:
-  - /donts-of-processes-for-upward-communication/
 related_notes:
   - concern-response-framework
   - upward-comms-asymmetric-commitment

--- a/_garden/vcs-should-match-development-model.md
+++ b/_garden/vcs-should-match-development-model.md
@@ -3,8 +3,6 @@ title: "VCS Should Match Your Development Model"
 maturity: evergreen
 tags: [software-engineering, version-control, development-model]
 created: 2026-04-27
-related_posts:
-  - /git-may-not-be-the-best-for-saas-companies/
 related_notes:
   - git-conflicts-with-trunk-based-saas
   - survival-vs-excellence-modes

--- a/_layouts/garden-note.html
+++ b/_layouts/garden-note.html
@@ -44,20 +44,6 @@ layout: default
       {{ content }}
     </div>
 
-    {% if page.related_posts.size > 0 %}
-    <div class="my-8 p-4 rounded-lg bg-neutral-100 dark:bg-neutral-900">
-      <h3 class="text-lg font-bold mb-2">📝 Related Blog Posts</h3>
-      <ul class="list-none pl-0">
-        {% for post_permalink in page.related_posts %}
-          {% assign rel_post = site.posts | where: "permalink", post_permalink | first %}
-          {% if rel_post %}
-            <li><a href="{{ rel_post.url | relative_url }}">{{ rel_post.title }}</a></li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-    </div>
-    {% endif %}
-
     {% if page.related_notes.size > 0 %}
     <div class="my-8 p-4 rounded-lg bg-neutral-100 dark:bg-neutral-900">
       <h3 class="text-lg font-bold mb-2">🌿 Related Notes</h3>

--- a/scripts/lint-pkm.sh
+++ b/scripts/lint-pkm.sh
@@ -229,49 +229,9 @@ for filepath in "${FILES[@]}"; do
         fi
     done
 
-    # ── Check 3: published_in validation ──────────────────────────────────
-    if [[ -n "$GARDEN_DIR" ]]; then
-        garden_file="$GARDEN_DIR/${my_slug}.md"
-        if [[ -f "$garden_file" ]]; then
-            # Garden file exists — PKM should have published_in
-            # Extract related_posts from garden file
-            mapfile -t garden_related_posts < <(get_fm_list "$garden_file" "related_posts")
-
-            if [[ ${#garden_related_posts[@]} -gt 0 ]] && [[ -n "${garden_related_posts[0]}" ]]; then
-                # Garden has related_posts — check published_in
-                if [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
-                    # Build a readable list of related_posts
-                    rp_display=""
-                    for rp in "${garden_related_posts[@]}"; do
-                        [[ -z "$rp" ]] && continue
-                        if [[ -n "$rp_display" ]]; then
-                            rp_display+=", $rp"
-                        else
-                            rp_display="$rp"
-                        fi
-                    done
-                    add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists with related_posts [$rp_display] but no published_in in PKM"
-                else
-                    # Both exist — check for mismatches
-                    declare -A pi_set=()
-                    for pi in "${published_in_raw[@]}"; do
-                        [[ -z "$pi" ]] && continue
-                        pi_set["$pi"]=1
-                    done
-                    for rp in "${garden_related_posts[@]}"; do
-                        [[ -z "$rp" ]] && continue
-                        if [[ -z "${pi_set[$rp]+x}" ]]; then
-                            add_error "$bname" "[PUBLISHED_IN_MISMATCH] garden related_posts has '$rp' but PKM published_in does not"
-                        fi
-                    done
-                    unset pi_set
-                fi
-            elif [[ ${#published_in_raw[@]} -eq 0 ]] || [[ -z "${published_in_raw[0]}" ]]; then
-                # Garden exists but no related_posts — still flag missing published_in
-                add_error "$bname" "[MISSING_PUBLISHED_IN] garden file exists at ${garden_file} but no published_in in PKM"
-            fi
-        fi
-    fi
+    # ── Check 3: garden file existence (informational) ─────────────────────
+    # Garden notes no longer store related_posts in frontmatter.
+    # Blog-post backlinks are computed at build time by garden_backlinks.html.
 
     # ── Check 5: published_in entries point to actual published posts ─────
     if [[ -n "$POSTS_DIR" ]] && [[ ${#published_in_raw[@]} -gt 0 ]]; then

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -53,17 +53,6 @@ fi
 
 mkdir -p "$GARDEN_DIR"
 
-# ── Build published-post permalink index ──────────────────────────
-# Scan all _posts/ files for their permalink: frontmatter values.
-# This is used to validate published_in entries.
-declare -A PUBLISHED_PERMALINKS
-while IFS= read -r pfile; do
-    plink=$(sed -n '/^---$/,/^---$/p' "$pfile" | grep -m1 '^permalink:' | sed 's/^permalink:[[:space:]]*//' || true)
-    if [ -n "$plink" ]; then
-        PUBLISHED_PERMALINKS["$plink"]=1
-    fi
-done < <(find "$REPO_DIR/_posts" -name '*.md' -type f 2>/dev/null)
-
 # ── Helper functions ──────────────────────────────────────────────
 
 # Extract a YAML frontmatter value by key (first match, single-line values only)
@@ -147,7 +136,7 @@ parse_inline_array() {
 # Convert a PKM reference path to a garden slug
 # brain/thoughts/thought-20260424-foo.md → foo
 # thoughts/thought-20260424-foo.md → foo
-# published/actor-model-ai-coding → (skip, these go to related_posts)
+# published/actor-model-ai-coding → (skip, these are blog posts not garden notes)
 # maps/guardrail-erosion → guardrail-erosion-map
 ref_to_slug() {
     local ref="$1"
@@ -161,7 +150,7 @@ ref_to_slug() {
     local dir
     dir=$(dirname "$ref")
 
-    # Skip published refs (those should be related_posts, handled separately)
+    # Skip published refs (blog posts, not garden notes)
     case "$dir" in
         published|*/published) echo "PUBLISHED:$base"; return ;;
     esac
@@ -294,31 +283,18 @@ for pkm_file in "${FILES[@]}"; do
     # Created date: prefer 'created', fallback to 'date_added'
     created="${pkm_created:-$pkm_date_added}"
 
-    # ── Collect related_notes and related_posts ──
+    # ── Collect related_notes ──
+    # (Blog-post relationships are handled by computed backlinks, not frontmatter.)
 
     related_notes=()
-    related_posts=()
 
-    # 1. Read published_in from PKM → related_posts (permalink format)
-    #    Validate each permalink against actual published posts in _posts/
-    while IFS= read -r pi; do
-        [ -z "$pi" ] && continue
-        pi=$(echo "$pi" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        # Validate against the published-post permalink index
-        if [[ -n "${PUBLISHED_PERMALINKS[$pi]+x}" ]]; then
-            related_posts+=("$pi")
-        else
-            echo "   ⚠  Skipping published_in '$pi' (no published post found in _posts/)"
-        fi
-    done < <(get_fm_list "$pkm_file" "published_in")
-
-    # 2. Process 'connects_to' (multi-line list)
+    # 1. Process 'connects_to' (multi-line list)
     while IFS= read -r ref; do
         [ -z "$ref" ] && continue
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            # Skip: published_in is canonical source for related_posts
+            # Published refs are blog posts, not garden notes — skip
             continue
         else
             related_notes+=("$resolved")
@@ -333,7 +309,7 @@ for pkm_file in "${FILES[@]}"; do
                 [ -z "$ref" ] && continue
                 resolved=$(ref_to_slug "$ref")
                 if [[ "$resolved" == PUBLISHED:* ]]; then
-                    # Skip: published_in is canonical source for related_posts
+                    # Published refs are blog posts, not garden notes — skip
             continue
                 else
                     related_notes+=("$resolved")
@@ -347,7 +323,7 @@ for pkm_file in "${FILES[@]}"; do
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            # Skip: published_in is canonical source for related_posts
+            # Published refs are blog posts, not garden notes — skip
             continue
         else
             related_notes+=("$resolved")
@@ -358,7 +334,7 @@ for pkm_file in "${FILES[@]}"; do
     if [ -n "$pkm_source" ]; then
         resolved=$(ref_to_slug "$pkm_source")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            : # Skip: published_in is canonical source for related_posts
+            : # Published refs are blog posts, not garden notes — skip
         else
             related_notes+=("$resolved")
         fi
@@ -371,7 +347,7 @@ for pkm_file in "${FILES[@]}"; do
                 [ -z "$ref" ] && continue
                 resolved=$(ref_to_slug "$ref")
                 if [[ "$resolved" == PUBLISHED:* ]]; then
-                    # Skip: published_in is canonical source for related_posts
+                    # Published refs are blog posts, not garden notes — skip
             continue
                 else
                     related_notes+=("$resolved")
@@ -380,7 +356,7 @@ for pkm_file in "${FILES[@]}"; do
         else
             resolved=$(ref_to_slug "$pkm_inspired_by")
             if [[ "$resolved" == PUBLISHED:* ]]; then
-                : # Skip: published_in is canonical source for related_posts
+                : # Published refs are blog posts, not garden notes — skip
             else
                 related_notes+=("$resolved")
             fi
@@ -392,7 +368,7 @@ for pkm_file in "${FILES[@]}"; do
         ref=$(echo "$ref" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         resolved=$(ref_to_slug "$ref")
         if [[ "$resolved" == PUBLISHED:* ]]; then
-            # Skip: published_in is canonical source for related_posts
+            # Published refs are blog posts, not garden notes — skip
             continue
         else
             related_notes+=("$resolved")
@@ -416,20 +392,6 @@ for pkm_file in "${FILES[@]}"; do
         fi
     done
     related_notes=("${validated_notes[@]+"${validated_notes[@]}"}")
-
-    # ── Deduplicate related_posts ──
-
-    if [ ${#related_posts[@]} -gt 0 ]; then
-        mapfile -t related_posts < <(printf '%s\n' "${related_posts[@]}" | sort -u)
-    fi
-
-    # ── Gate: garden notes require at least one linked post ──
-
-    if [ ${#related_posts[@]} -eq 0 ]; then
-        echo "⏭  Skipping $slug (no related_posts — garden notes require at least one linked post)"
-        skipped_count=$((skipped_count + 1))
-        continue
-    fi
 
     # ── Extract and process body ──
 
@@ -482,28 +444,6 @@ for pkm_file in "${FILES[@]}"; do
             fi
         done
 
-        # (c) related_posts loss
-        existing_rposts=()
-        while IFS= read -r erp; do
-            [ -z "$erp" ] && continue
-            erp=$(echo "$erp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            existing_rposts+=("$erp")
-        done < <(get_fm_list "$garden_file" "related_posts")
-
-        missing_rposts=()
-        for erp in "${existing_rposts[@]+"${existing_rposts[@]}"}"; do
-            found=false
-            for rp in "${related_posts[@]+"${related_posts[@]}"}"; do
-                if [ "$rp" = "$erp" ]; then
-                    found=true
-                    break
-                fi
-            done
-            if [ "$found" = false ]; then
-                missing_rposts+=("$erp")
-            fi
-        done
-
         # Report losses and block if any
         has_loss=false
 
@@ -511,9 +451,6 @@ for pkm_file in "${FILES[@]}"; do
             has_loss=true
         fi
         if [ ${#missing_rnotes[@]} -gt 0 ]; then
-            has_loss=true
-        fi
-        if [ ${#missing_rposts[@]} -gt 0 ]; then
             has_loss=true
         fi
 
@@ -535,14 +472,6 @@ for pkm_file in "${FILES[@]}"; do
                 done
                 echo "   Missing connects_to in PKM: $rnotes_display"
             fi
-            if [ ${#missing_rposts[@]} -gt 0 ]; then
-                rposts_display=""
-                for mp in "${missing_rposts[@]}"; do
-                    [ -n "$rposts_display" ] && rposts_display+=", "
-                    rposts_display+="$mp"
-                done
-                echo "   Missing published_in in PKM: $rposts_display"
-            fi
             echo "   Fix the PKM note first, then re-run."
             blocked_count=$((blocked_count + 1))
             continue
@@ -562,12 +491,6 @@ for pkm_file in "${FILES[@]}"; do
         if [ -n "$created" ]; then
             echo "created: $created"
         fi
-
-        # Related posts
-        echo "related_posts:"
-        for rp in "${related_posts[@]}"; do
-            echo "  - $rp"
-        done
 
         # Related notes
         if [ ${#related_notes[@]} -gt 0 ]; then
@@ -614,7 +537,6 @@ if [ $created_count -gt 0 ]; then
     echo "Next steps:"
     echo "  1. Review generated files in _garden/"
     echo "  2. Adjust titles, maturity levels, and excerpt_text"
-    echo "  3. Add published_in permalinks to PKM notes for related_posts"
-    echo "  4. Add related_notes slugs for connected garden entries"
-    echo "  5. Add inline wikilinks in PKM body for garden cross-references"
+    echo "  3. Add related_notes slugs for connected garden entries"
+    echo "  4. Add inline wikilinks in PKM body for garden cross-references"
 fi

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -484,6 +484,7 @@ for pkm_file in "${FILES[@]}"; do
         echo "---"
         echo "title: \"$title\""
 
+        echo "garden_type: $pkm_type"
         echo "maturity: $maturity"
         if [ -n "$tags_line" ]; then
             echo "tags: $tags_line"


### PR DESCRIPTION
## What

Removes the manual `related_posts` frontmatter from all 76 garden notes and the code that generates/renders it. Blog-post connections are now solely handled by the computed **🔗 Backlinks** section (`garden_backlinks.html`), which scans post content for garden links at build time.

## Why

The manual `related_posts` list was redundant with computed backlinks. When both were in sync, the same post appeared in two separate sections on the page. When they drifted — which happened in 25/76 notes — readers saw confusing mismatches between "Related Blog Posts" and "Backlinks".

Single source of truth: if a post links to a garden note inline, the backlink appears automatically. No manual frontmatter to maintain.

## Changes

| Area | Change |
|------|--------|
| `_garden/*.md` (76 files) | Stripped `related_posts:` from YAML frontmatter |
| `_layouts/garden-note.html` | Removed the "📝 Related Blog Posts" rendering block |
| `scripts/pkm-to-garden.sh` | Removed: published-post permalink index, `related_posts` collection/dedup/gate, pre-sync guard for related_posts loss, frontmatter output of related_posts |
| `scripts/lint-pkm.sh` | Removed Check 3 (related_posts ↔ published_in validation) |

## Verification

Post-cleanup diagnostic:
- ✅ All 72 post→garden inline links target valid garden notes
- ✅ All garden links use consistent trailing-slash format
- ✅ Perfect bidirectional consistency (every post→garden link produces a backlink)
- 🔕 18/76 garden notes are orphaned (no post links to them) — these are notes tied to older posts that predate the garden and never had inline links added. They remain reachable via the garden index and note-to-note `related_notes` links.

## What still works

- **🌿 Related Notes** section (from `related_notes` frontmatter) — unchanged
- **🔗 Backlinks** section (computed by `garden_backlinks.html`) — this was always the real backlinks engine; now it's the only one
- Garden index page, maturity badges, source metadata — all unchanged