### PR TITLE
Fix: pkm-to-garden-astro.sh carries related_posts; deduplicate Backlinks vs RelatedNotes

### DIFF
--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -260,6 +260,17 @@ for pkm_file in "${FILES[@]}"; do
     pkm_source=$(get_fm "$pkm_file" "source")
     pkm_inspired_by=$(get_fm "$pkm_file" "inspired_by")
 
+    # Collect related_posts (multi-line list of post slugs)
+    related_posts=()
+    while IFS= read -r rp; do
+        [ -z "$rp" ] && continue
+        rp=$(echo "$rp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        # Normalize to /slug/ format
+        rp="${rp#/}"   # strip leading slash if present
+        rp="${rp%/}"   # strip trailing slash if present
+        related_posts+=("/$rp/")
+    done < <(get_fm_list "$pkm_file" "related_posts")
+
     # ── Derive garden fields ──
 
     # Title: use PKM title, or derive from slug
@@ -510,6 +521,14 @@ for pkm_file in "${FILES[@]}"; do
             done
         else
             echo "related_notes: []"
+        fi
+
+        # Related posts
+        if [ ${#related_posts[@]} -gt 0 ]; then
+            echo "related_posts:"
+            for rp in "${related_posts[@]}"; do
+                echo "  - $rp"
+            done
         fi
 
         # Source-specific fields

--- a/src/components/Backlinks.astro
+++ b/src/components/Backlinks.astro
@@ -5,9 +5,14 @@ import { getCollection } from 'astro:content'
 interface Props {
   currentId: string
   collection: 'garden' | 'posts'
+  excludeNotes?: string[]
+  excludePosts?: string[]
 }
 
-const { currentId, collection } = Astro.props
+const { currentId, collection, excludeNotes = [], excludePosts = [] } = Astro.props
+
+// Normalize excludePosts to bare slugs for comparison
+const excludePostSlugs = new Set(excludePosts.map((p: string) => p.replace(/^\/|\/$/g, '')))
 
 // Gather all garden notes and posts
 const allNotes: CollectionEntry<'garden'>[] = await getCollection('garden')
@@ -40,6 +45,9 @@ const gardenUrlPatternNoTrail = `/garden/${currentSlug}`
 // Check garden notes for backlinks
 for (const note of allNotes) {
   if (note.id === currentId && collection === 'garden') continue
+
+  // Skip notes already shown in RelatedNotes
+  if (excludeNotes.includes(note.id)) continue
 
   // Check related_notes frontmatter
   const relatedNotes = note.data.related_notes || []
@@ -91,10 +99,14 @@ for (const note of allNotes) {
 // Check posts for backlinks to garden notes
 if (collection === 'garden') {
   for (const post of allPosts) {
+    const postSlug = post.data.abbrlink || post.id
+
+    // Skip posts already shown in RelatedNotes
+    if (excludePostSlugs.has(postSlug)) continue
+
     // Check body for inline links to this garden note
     if (post.body) {
       if (post.body.includes(gardenUrlPattern) || post.body.includes(gardenUrlPatternNoTrail)) {
-        const postSlug = post.data.abbrlink || post.id
         backlinks.push({
           title: post.data.title,
           href: `/${postSlug}/`,

--- a/src/pages/garden/[slug].astro
+++ b/src/pages/garden/[slug].astro
@@ -65,8 +65,13 @@ const badge = maturityBadge[note.data.maturity] ?? maturityBadge.seedling
         relatedPosts={note.data.related_posts || []}
       />
 
-      <!-- Backlinks (discovered connections) -->
-      <Backlinks currentId={note.id} collection="garden" />
+      <!-- Backlinks (discovered connections, excluding already-shown related items) -->
+      <Backlinks
+        currentId={note.id}
+        collection="garden"
+        excludeNotes={note.data.related_notes || []}
+        excludePosts={note.data.related_posts || []}
+      />
     </div>
   </article>
 </Layout>


### PR DESCRIPTION
Two related fixes:

1. **pkm-to-garden-astro.sh**: Now reads `related_posts` from PKM frontmatter and writes it to garden output, normalized to `/slug/` format. Previously this field was silently dropped.

2. **Backlinks.astro**: Accepts `excludeNotes` and `excludePosts` props. The garden page passes the note's `related_notes` and `related_posts` so Backlinks skips anything RelatedNotes already displays. Eliminates duplicate entries between Related and Linked From sections.