### PR TITLE
Remove tag links from garden notes

### DIFF
--- a/src/pages/garden/[slug].astro
+++ b/src/pages/garden/[slug].astro
@@ -3,7 +3,6 @@ import type { CollectionEntry } from 'astro:content'
 import { getCollection, render } from 'astro:content'
 import Backlinks from '@/components/Backlinks.astro'
 import RelatedNotes from '@/components/RelatedNotes.astro'
-import TagList from '@/components/TagList.astro'
 import BackButton from '@/components/Widgets/BackButton.astro'
 import Layout from '@/layouts/Layout.astro'
 
@@ -52,12 +51,6 @@ const badge = maturityBadge[note.data.maturity] ?? maturityBadge.seedling
     <!-- Content -->
     <div id="post-content">
       <Content />
-
-      <!-- Tags -->
-      {note.data.tags?.length > 0 && (
-        <div class="mt-12.6 uno-decorative-line" />
-        <TagList tags={note.data.tags} lang="en" />
-      )}
 
       <!-- Related Notes (authored connections) -->
       <RelatedNotes


### PR DESCRIPTION
Garden note tags link to /tags/<tag>/ pages, but those pages are only generated from the posts collection. Clicking a garden tag returns a 404. This removes the TagList render from garden notes until tags are properly unified across collections.