### PR TITLE
Remove tag links from garden notes

### DIFF
--- a/src/pages/garden/[slug].astro
+++ b/src/pages/garden/[slug].astro
@@ -2,7 +2,6 @@
 import type { CollectionEntry } from 'astro:content'
 import { getCollection, render } from 'astro:content'
 import Backlinks from '@/components/Backlinks.astro'
-import TagList from '@/components/TagList.astro'
 import BackButton from '@/components/Widgets/BackButton.astro'
 import Layout from '@/layouts/Layout.astro'
 
@@ -51,12 +50,6 @@ const badge = maturityBadge[note.data.maturity] ?? maturityBadge.seedling
     <!-- Content -->
     <div id="post-content">
       <Content />
-
-      <!-- Tags -->
-      {note.data.tags?.length > 0 && (
-        <div class="mt-12.6 uno-decorative-line" />
-        <TagList tags={note.data.tags} lang="en" />
-      )}
 
       <!-- Connections (forward declarations + discovered backlinks, unified) -->
       <Backlinks

--- a/src/pages/garden/index.astro
+++ b/src/pages/garden/index.astro
@@ -56,13 +56,6 @@ for (const m of maturityOrder) {
             {note.data.excerpt_text && (
               <p class="c-secondary text-3.25 leading-relaxed mb-2 line-clamp-2">{note.data.excerpt_text}</p>
             )}
-            {note.data.tags && note.data.tags.length > 0 && (
-              <div class="flex flex-wrap gap-1.5">
-                {note.data.tags.slice(0, 3).map((tag: string) => (
-                  <span class="text-2.75 px-1.5 py-0.5 rounded-full bg-secondary/8 c-secondary/70">{tag}</span>
-                ))}
-              </div>
-            )}
           </a>
         ))}
       </div>


### PR DESCRIPTION
Garden note tags link to /tags/<tag>/ pages, but those pages are only generated from the posts collection. Clicking a garden tag returns a 404. This removes the TagList render from garden notes until tags are properly unified across collections.