### PR TITLE
Fix: pkm-to-garden-astro.sh carries related_posts

### DIFF
--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -260,6 +260,17 @@ for pkm_file in "${FILES[@]}"; do
     pkm_source=$(get_fm "$pkm_file" "source")
     pkm_inspired_by=$(get_fm "$pkm_file" "inspired_by")
 
+    # Collect related_posts (multi-line list of post slugs)
+    related_posts=()
+    while IFS= read -r rp; do
+        [ -z "$rp" ] && continue
+        rp=$(echo "$rp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        # Normalize to /slug/ format
+        rp="${rp#/}"   # strip leading slash if present
+        rp="${rp%/}"   # strip trailing slash if present
+        related_posts+=("/$rp/")
+    done < <(get_fm_list "$pkm_file" "related_posts")
+
     # ── Derive garden fields ──
 
     # Title: use PKM title, or derive from slug
@@ -510,6 +521,14 @@ for pkm_file in "${FILES[@]}"; do
             done
         else
             echo "related_notes: []"
+        fi
+
+        # Related posts
+        if [ ${#related_posts[@]} -gt 0 ]; then
+            echo "related_posts:"
+            for rp in "${related_posts[@]}"; do
+                echo "  - $rp"
+            done
         fi
 
         # Source-specific fields


### PR DESCRIPTION
The garden script now reads related_posts from PKM frontmatter and writes them to garden output, normalized to /slug/ format. Split from #137 (which also had Backlinks changes now superseded by #138).