### PR TITLE
Sync garden note maturity from PKM

### DIFF
--- a/src/content/garden/ai-reviewing-ai-shared-blind-spots.md
+++ b/src/content/garden/ai-reviewing-ai-shared-blind-spots.md
@@ -1,6 +1,6 @@
 ---
 title: "AI Reviewing AI: Shared Blind Spots"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, ai-review, blind-spots, model-collapse]
 created: 2026-04-24
 related_notes:

--- a/src/content/garden/confabulation-is-plausible.md
+++ b/src/content/garden/confabulation-is-plausible.md
@@ -1,6 +1,6 @@
 ---
 title: "Confabulation Is Plausible"
-maturity: budding
+maturity: evergreen
 tags: [ai, failure-modes, hallucination]
 created: 2026-04-24
 related_notes:

--- a/src/content/garden/crisis-centralization-ratchet.md
+++ b/src/content/garden/crisis-centralization-ratchet.md
@@ -1,6 +1,6 @@
 ---
 title: "Crisis Centralization Ratchet"
-maturity: budding
+maturity: evergreen
 tags: [governance, centralization, crisis, tech-industry, wartime-ceo]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/data-pipeline-is-achilles-heel.md
+++ b/src/content/garden/data-pipeline-is-achilles-heel.md
@@ -1,6 +1,6 @@
 ---
 title: "Data Pipeline Is Achilles Heel"
-maturity: budding
+maturity: evergreen
 tags: [governance, bounded-rationality, information-asymmetry, data-quality]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/delegation-mimicry-without-cultural-substrate.md
+++ b/src/content/garden/delegation-mimicry-without-cultural-substrate.md
@@ -1,6 +1,6 @@
 ---
 title: "Delegation Mimicry Without Cultural Substrate"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, delegation, cultural-substrate, isomorphism]
 created: 2026-04-26
 related_notes:

--- a/src/content/garden/directive-governance-cargo-cult.md
+++ b/src/content/garden/directive-governance-cargo-cult.md
@@ -1,6 +1,6 @@
 ---
 title: "Directive Governance Cargo Cult"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, mechanistic-organization, cargo-cult]
 created: 2026-04-27
 related_notes:

--- a/src/content/garden/directive-governance-degrades-not-destroys.md
+++ b/src/content/garden/directive-governance-degrades-not-destroys.md
@@ -1,6 +1,6 @@
 ---
 title: "Directive Governance Degrades Not Destroys"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, monopoly-rents, rebuttal]
 created: 2026-04-26
 related_notes:

--- a/src/content/garden/directive-governance-preconditions.md
+++ b/src/content/garden/directive-governance-preconditions.md
@@ -1,6 +1,6 @@
 ---
 title: "Directive Governance Preconditions"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, preconditions]
 created: 2026-04-27
 related_notes:

--- a/src/content/garden/encoded-guardrails-suppress-symptoms.md
+++ b/src/content/garden/encoded-guardrails-suppress-symptoms.md
@@ -1,6 +1,6 @@
 ---
 title: "Encoded Guardrails Suppress Symptoms Without Addressing the Cause"
-maturity: budding
+maturity: evergreen
 tags: [suggestible-actor, guardrail-erosion, security, guardrail-taxonomy]
 created: 2026-04-26
 related_notes:

--- a/src/content/garden/encoded-guardrails.md
+++ b/src/content/garden/encoded-guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: "Encoded Guardrails"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, suggestible-actor, guardrail-taxonomy]
 created: 2026-05-17
 related_notes:

--- a/src/content/garden/expected-damage-severity-times-mitigation.md
+++ b/src/content/garden/expected-damage-severity-times-mitigation.md
@@ -1,6 +1,6 @@
 ---
 title: "Expected Damage: Severity Times Time to Mitigation"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, risk-framework, decision-theory]
 created: 2026-05-17
 related_notes:

--- a/src/content/garden/guardrail-erosion-meta-problem.md
+++ b/src/content/garden/guardrail-erosion-meta-problem.md
@@ -1,6 +1,6 @@
 ---
 title: "Guardrail Erosion Is a Meta-Problem"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, suggestible-actor, self-reinforcing]
 created: 2026-04-24
 related_notes:

--- a/src/content/garden/isomorphic-mimicry-in-tech-governance.md
+++ b/src/content/garden/isomorphic-mimicry-in-tech-governance.md
@@ -1,6 +1,6 @@
 ---
 title: "Isomorphic Mimicry In Tech Governance"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, institutional-theory, isomorphism, tech-industry]
 created: 2026-04-26
 related_notes:

--- a/src/content/garden/metrics-measure-maintenance-not-creation.md
+++ b/src/content/garden/metrics-measure-maintenance-not-creation.md
@@ -1,6 +1,6 @@
 ---
 title: "Metrics Measure Maintenance Not Creation"
-maturity: budding
+maturity: evergreen
 tags: [metrics, governance, innovation, qualitative-signal-loss]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/partial-measurement-worse-than-none.md
+++ b/src/content/garden/partial-measurement-worse-than-none.md
@@ -1,6 +1,6 @@
 ---
 title: "Partial Measurement Worse Than None"
-maturity: budding
+maturity: evergreen
 tags: [metrics, measurement, governance, austin]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/serial-satisficing-without-learning.md
+++ b/src/content/garden/serial-satisficing-without-learning.md
@@ -1,6 +1,6 @@
 ---
 title: "Serial Satisficing Without Learning"
-maturity: budding
+maturity: evergreen
 tags: [bounded-rationality, governance, layoffs, decision-making]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/social-guardrails.md
+++ b/src/content/garden/social-guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: "Social Guardrails"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, suggestible-actor, guardrail-taxonomy]
 created: 2026-05-17
 related_notes:

--- a/src/content/garden/structural-guardrails.md
+++ b/src/content/garden/structural-guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: "Structural Guardrails"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, suggestible-actor, guardrail-taxonomy]
 created: 2026-05-17
 related_notes:

--- a/src/content/garden/susceptibility-peaks-at-failure.md
+++ b/src/content/garden/susceptibility-peaks-at-failure.md
@@ -1,6 +1,6 @@
 ---
 title: "Susceptibility Peaks at Failure"
-maturity: budding
+maturity: evergreen
 tags: [ai, software-design, design-levers]
 created: 2026-04-24
 related_notes:

--- a/src/content/garden/three-assumptions-framework.md
+++ b/src/content/garden/three-assumptions-framework.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Assumptions Framework"
-maturity: budding
+maturity: evergreen
 tags: [governance, directive-governance, information-theory, original-framework, tech-industry]
 created: 2026-04-26
 related_notes:

--- a/src/content/garden/three-classes-of-guardrail-erosion-resistance.md
+++ b/src/content/garden/three-classes-of-guardrail-erosion-resistance.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Classes of Guardrail Erosion Resistance"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, taxonomy, formal-verification, suggestible-actor]
 created: 2026-04-24
 related_notes:

--- a/src/content/garden/three-dimensions-of-erosion-resistance-allocation.md
+++ b/src/content/garden/three-dimensions-of-erosion-resistance-allocation.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Dimensions of Erosion Resistance Allocation"
-maturity: budding
+maturity: evergreen
 tags: [guardrail-erosion, risk-framework, decision-theory]
 created: 2026-05-17
 related_notes:

--- a/src/content/garden/tooling-advances-prove-brooks-right.md
+++ b/src/content/garden/tooling-advances-prove-brooks-right.md
@@ -1,6 +1,6 @@
 ---
 title: "Tooling Advances Prove Brooks Right"
-maturity: budding
+maturity: evergreen
 tags: [software-engineering, brooks, essential-complexity, tooling]
 created: 2026-04-25
 related_notes:

--- a/src/content/garden/unfalsifiable-organizational-corrections.md
+++ b/src/content/garden/unfalsifiable-organizational-corrections.md
@@ -1,6 +1,6 @@
 ---
 title: "Unfalsifiable Organizational Corrections"
-maturity: budding
+maturity: evergreen
 tags: [bounded-rationality, governance, epistemology, decision-making]
 created: 2026-04-25
 related_notes:


### PR DESCRIPTION
24 garden notes updated from budding to evergreen to match their PKM source maturity. These notes were extracted from published posts during the April backfill — their formulations are stable. Only the explicit budding/seedling notes in the PKM (Act 4/5 candidates, exploratory research threads) retain non-evergreen status, but those don't have garden counterparts on main.