### PR TITLE
Fix: garden script reads maturity field from PKM notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Review PKM items (thoughts, notes, sources) related to the post. Not everything 
 
 The script generates `src/content/garden/` files with frontmatter derived from your PKM. Review and adjust:
 - **Title** — auto-derived from the slug if missing; verify it reads well
-- **Maturity** — auto-derived from PKM status; override if wrong
+- **Maturity** — auto-derived from PKM `maturity` field; override if wrong
 - **Excerpt** — auto-extracted first sentence; tighten if needed
 - **Related notes** — auto-populated from PKM cross-refs; add any missing
 
@@ -59,13 +59,13 @@ Read each new garden note. For every concept mentioned that has its own garden e
 
 ### 5. Set Maturity Levels
 
-Review each note and assign the right maturity:
+Review each note and assign the right maturity (same `maturity` field in both PKM and garden):
 
-| Maturity | When to use | PKM equivalent |
-|----------|-------------|----------------|
-| 🌱 `seedling` | Early idea, might change substantially | `raw` or no status |
-| 🌿 `budding` | Developed argument with room to grow | `developing` or `draft` |
-| 🌳 `evergreen` | Stable definition/framework, unlikely to change | `connected` or `stable` |
+| Maturity | When to use |
+|----------|-------------|
+| 🌱 `seedling` | Early idea, might change substantially |
+| 🌿 `budding` | Developed argument with room to grow |
+| 🌳 `evergreen` | Stable definition/framework, unlikely to change |
 
 Sources default to `evergreen`.
 
@@ -82,15 +82,9 @@ git commit -m "Add post: Your Title + garden notes"
 git push origin post/your-post-slug
 ```
 
-### 7. Update PKM Status
+### 7. Verify PKM Maturity
 
-After publishing, update the PKM thought `status` fields to match the garden maturity:
-
-| Garden maturity | PKM status |
-|----------------|------------|
-| `seedling` | `raw` |
-| `budding` | `developing` |
-| `evergreen` | `connected` |
+After publishing, verify the PKM `maturity` fields match the garden maturity. Since both use the same vocabulary (`seedling`, `budding`, `evergreen`), they should already be in sync from the conversion step.
 
 ---
 

--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -249,6 +249,7 @@ for pkm_file in "${FILES[@]}"; do
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
     pkm_status=$(get_fm "$pkm_file" "status")
+    [ -z "$pkm_status" ] && pkm_status=$(get_fm "$pkm_file" "maturity")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")

--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -112,15 +112,15 @@ kebab_to_title() {
     echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) tolower(substr($i,2))}}1'
 }
 
-# Derive maturity from PKM status and type
+# Derive maturity from PKM maturity field and type
 derive_maturity() {
-    local pkm_type="$1" status="$2"
+    local pkm_type="$1" pkm_maturity="$2"
     # Sources default to evergreen
     if [ "$pkm_type" = "source" ]; then
         echo "evergreen"
         return
     fi
-    case "$status" in
+    case "$pkm_maturity" in
         evergreen|connected|stable) echo "evergreen" ;;
         budding|developing|draft)   echo "budding" ;;
         seedling|raw|"")            echo "seedling" ;;
@@ -248,8 +248,8 @@ for pkm_file in "${FILES[@]}"; do
 
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
-    pkm_status=$(get_fm "$pkm_file" "status")
-    [ -z "$pkm_status" ] && pkm_status=$(get_fm "$pkm_file" "maturity")
+    pkm_maturity=$(get_fm "$pkm_file" "maturity")
+    [ -z "$pkm_maturity" ] && pkm_maturity=$(get_fm "$pkm_file" "status")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")
@@ -282,7 +282,7 @@ for pkm_file in "${FILES[@]}"; do
     fi
 
     # Maturity
-    maturity=$(derive_maturity "$pkm_type" "$pkm_status")
+    maturity=$(derive_maturity "$pkm_type" "$pkm_maturity")
 
     # Tags: parse inline array format [a, b, c]
     tags_line=""

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -110,15 +110,15 @@ kebab_to_title() {
     echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) tolower(substr($i,2))}}1'
 }
 
-# Derive maturity from PKM status and type
+# Derive maturity from PKM maturity field and type
 derive_maturity() {
-    local pkm_type="$1" status="$2"
+    local pkm_type="$1" pkm_maturity="$2"
     # Sources default to evergreen
     if [ "$pkm_type" = "source" ]; then
         echo "evergreen"
         return
     fi
-    case "$status" in
+    case "$pkm_maturity" in
         evergreen|connected|stable) echo "evergreen" ;;
         budding|developing|draft)   echo "budding" ;;
         seedling|raw|"")            echo "seedling" ;;
@@ -246,7 +246,8 @@ for pkm_file in "${FILES[@]}"; do
 
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
-    pkm_status=$(get_fm "$pkm_file" "status")
+    pkm_maturity=$(get_fm "$pkm_file" "maturity")
+    [ -z "$pkm_maturity" ] && pkm_maturity=$(get_fm "$pkm_file" "status")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")
@@ -268,7 +269,7 @@ for pkm_file in "${FILES[@]}"; do
     fi
 
     # Maturity
-    maturity=$(derive_maturity "$pkm_type" "$pkm_status")
+    maturity=$(derive_maturity "$pkm_type" "$pkm_maturity")
 
     # Tags: parse inline array format [a, b, c]
     tags_line=""

--- a/src/content/garden/broken-reciprocity-as-fatigue-accelerant.md
+++ b/src/content/garden/broken-reciprocity-as-fatigue-accelerant.md
@@ -1,0 +1,22 @@
+---
+title: "Broken Reciprocity as Fatigue Accelerant in Human-AI Interaction"
+maturity: seedling
+tags: [human-ai-interaction, emotional-labor, cognitive-depletion, reciprocity]
+created: 2026-06-01
+related_notes:
+  - categorical-ambiguity-of-ai
+  - relational-mode-oscillation
+  - role-switching-frequency-predicts-stress
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  Human-AI interaction is genuinely social and effortful, but AI provides no emotional reciprocity — so the cognitive depletion from each relational switch accumulates without attenuation.
+---
+
+**Human-AI interaction is genuinely social and effortful, but AI provides no emotional reciprocity — so the cognitive depletion from each relational switch accumulates without attenuation.** Banks (2026, "Ghosting the Machine") argues that human-agent interaction is genuinely social, not parasocial, which means the depletion from emotional labor is real, not performative.
+
+In human interaction, social reciprocity partially replenishes cognitive resources between role switches. A thank-you, visible understanding, a smile — these recovery mechanisms are built into the interaction. This is why you can switch relational modes all day with colleagues and still function: each switch costs, but the reciprocity loop partially offsets the depletion between switches.
+
+AI returns well-formed output and functional feedback, but not emotional reciprocity. The loop is structurally broken. You're paying the performance cost at every switch with no recovery mechanism between switches. The switching costs from [relational-mode-oscillation](/garden/relational-mode-oscillation/) accumulate without attenuation.
+
+**Why this isn't the whole story:** If broken reciprocity alone explained AI fatigue, any sustained LLM interaction would be equally fatiguing — a long single-mode directive session would drain you the same way a complex multi-mode pair-programming session does. That's not what people report. The fatigue is specifically worse in sessions with frequent mode changes. The switching is the driver; broken reciprocity is why the costs don't fade.

--- a/src/content/garden/casa-framework.md
+++ b/src/content/garden/casa-framework.md
@@ -1,0 +1,17 @@
+---
+title: "CASA: Computers Are Social Actors"
+maturity: evergreen
+tags: [hci, social-cognition, human-ai-interaction]
+created: 2026-06-01
+related_notes:
+  - casa-habituation
+  - categorical-ambiguity-of-ai
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  People apply social rules to computers mindlessly — the response is automatic and below conscious awareness, not effortful anthropomorphism.
+---
+
+**People apply social rules to computers mindlessly — the response is automatic and below conscious awareness, not effortful anthropomorphism.** Nass & Moon (2000) formalized this as the CASA (Computers Are Social Actors) framework: minimal social cues from a computer (using "I," adopting a gendered voice, displaying a name) are sufficient to trigger social scripts in users. People are polite to computers, reciprocate self-disclosure, apply gender stereotypes, and treat computers as teammates — all while explicitly denying that they would do so.
+
+The critical feature of CASA is that the social cues are *minimal and coherent*. The computer says "I" consistently, or uses a single gendered voice. The cues point in one direction, the social frame activates, and nothing contradicts it. This coherence is what allows the frame to stabilize. When social cues become rich but *inconsistent* — as with modern AI agents — CASA's predictions about stable social framing may break down. See [categorical-ambiguity-of-ai](/garden/categorical-ambiguity-of-ai/).

--- a/src/content/garden/casa-habituation.md
+++ b/src/content/garden/casa-habituation.md
@@ -1,0 +1,17 @@
+---
+title: "CASA Habituation: Social Responses to Computers Diminish with Familiarity"
+maturity: evergreen
+tags: [hci, social-cognition, human-ai-interaction, habituation]
+created: 2026-06-01
+related_notes:
+  - casa-framework
+  - categorical-ambiguity-of-ai
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  The CASA effect no longer replicates for people who grew up with desktop computers.
+---
+
+**The CASA effect no longer replicates for people who grew up with desktop computers.** Heyselaar (2023) attempted to replicate the original Nass & Moon CASA experiments with participants habituated to computer interaction. The automatic social responses that defined CASA — politeness, reciprocity, stereotype application — were significantly attenuated or absent. The implication is that CASA's social-response effect is tied to technology novelty, not a permanent feature of human cognition.
+
+This raises the strongest counterargument to relational instability theories of AI fatigue: if social responses to computers habituate, perhaps the relational oscillation users experience with AI agents will also fade with exposure. But there is a structural reason it may not. Desktop computers presented minimal, consistent social cues that users could learn to categorize and dismiss. AI agents present *rich, inconsistent* social cues — deferring like a subordinate, asserting like a peer, explaining like a teacher — that resist stable categorization. Habituation to a fixed stimulus is well-documented; habituation to a stimulus that changes its categorical signals on every interaction is not. See [categorical-ambiguity-of-ai](/garden/categorical-ambiguity-of-ai/).

--- a/src/content/garden/categorical-ambiguity-of-ai.md
+++ b/src/content/garden/categorical-ambiguity-of-ai.md
@@ -1,0 +1,23 @@
+---
+title: "Categorical Ambiguity of AI Agents"
+maturity: budding
+tags: [human-ai-interaction, social-cognition, ontological-ambiguity]
+created: 2026-06-01
+related_notes:
+  - broken-reciprocity-as-fatigue-accelerant
+  - casa-framework
+  - casa-habituation
+  - relational-mode-oscillation
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  AI agents resist relational stabilization because their social cues are rich but inconsistent.
+---
+
+**AI agents resist relational stabilization because their social cues are rich but inconsistent.** With a human colleague, you settle into a relational mode quickly — "this is my manager," "this is my collaborator" — and it runs on autopilot. With a tool, you settle into "this is a tool" and the framing never wavers. AI agents occupy a unique position: they are categorically ambiguous in a way that resists either settlement.
+
+The [CASA framework](/garden/casa-framework/) predicted that social cues from computers trigger automatic social responses, and that more social cues produce more stable social frames. But CASA was formulated around minimal, consistent cues: a computer that says "I" or uses a gendered voice. The cues point in one direction, the frame activates, and nothing contradicts it.
+
+AI agents break this because the social cues are rich but *inconsistent from the same entity*. The AI defers like a subordinate, then asserts like a peer, then explains like a teacher, then mirrors your register back at you — all in the same conversation. When social cues are contradictory, more cues means more conflicting signals, which deepens ambiguity instead of resolving it. You say it is a tool; you know it is a tool; you want to use it as a tool. Yet when you actually start using it, your relationship with it changes, and it changes continually. We are perpetually in a situationship with the AI.
+
+**Open question:** Does this ambiguity habituate? [CASA habituation](/garden/casa-habituation/) shows that *consistent* social cues lose their effect with exposure. But habituation to a stimulus that changes its categorical signals on every interaction is structurally different and untested.

--- a/src/content/garden/relational-mode-oscillation.md
+++ b/src/content/garden/relational-mode-oscillation.md
@@ -1,0 +1,22 @@
+---
+title: "Relational Mode Oscillation in Human-AI Interaction"
+maturity: budding
+tags: [human-ai-interaction, relational-dynamics, cognitive-load]
+created: 2026-06-01
+related_notes:
+  - casa-framework
+  - categorical-ambiguity-of-ai
+  - role-switching-frequency-predicts-stress
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  Users of LLMs unconsciously oscillate between five relational modes — Director, Trainer, Partner, Student, Consumer — within single interactions, often within minutes.
+---
+
+**Users of LLMs unconsciously oscillate between five relational modes — Director, Trainer, Partner, Student, Consumer — within single interactions, often within minutes.** Gülay et al. (2025) studied 22 knowledge workers and found that 14 of 22 explicitly framed the AI as "just a tool" while behaviorally praising it, teaching it patiently, or deferring to its suggestions. The gap between stated positioning and enacted dynamics operates below conscious awareness.
+
+Map this to a typical coding session: you start commanding ("refactor this function"), shift to collaborating ("what if we tried X instead?"), find yourself teaching ("no, the constraint is Y because..."), then deferring ("actually your approach is better"), then passively reviewing output. Five modes. One conversation. You didn't decide to switch. You just did.
+
+Yang & Ma (2025) independently found five *epistemic* relationship types — Instrumental Reliance, Contingent Delegation, Co-agency Collaboration, Authority Displacement, Epistemic Abstention — with the same structural finding: roles are "dynamic and context-dependent." Their lens is epistemological (how do I know things with this entity?) where Gülay's is relational (what am I to this entity?). Multiple groups carving this space with different vocabularies suggests the oscillation phenomenon is real even if the right framework for describing it is unsettled.
+
+**Limitations:** Gülay: N=22, workshop sessions, not daily use. Yang & Ma: epistemic focus, not affective. Converging first evidence, not proof.

--- a/src/content/garden/role-switching-frequency-predicts-stress.md
+++ b/src/content/garden/role-switching-frequency-predicts-stress.md
@@ -1,0 +1,18 @@
+---
+title: "Social Role-Switching Frequency Predicts Stress"
+maturity: evergreen
+tags: [social-psychology, stress, role-theory, cognitive-load]
+created: 2026-06-01
+related_notes:
+  - relational-mode-oscillation
+related_posts:
+  - /relational-switching-costs/
+excerpt_text: >
+  Social role-switching frequency predicts stress independent of role count.
+---
+
+**Social role-switching frequency predicts stress independent of role count.** Cornwell (2013) studied 7,662 respondents using time diary data from the American Time Use Survey and found that it's not having more roles that is stressful — it's switching between them more often. The switching itself is the cost, independent of the total number of roles a person occupies.
+
+Cornwell's framing: "A key paradox of social life is that a rich and supportive social network creates a complex of microsocial problems associated with sequencing social interactions, synchronizing schedules, and transitioning between contexts." This contradicts the intuition that role *overload* is the primary mechanism — the mechanism is role *switching*.
+
+Cornwell measures macro-role switches across a day (parent → professional → friend), at roughly 20 transitions per day. LLM interaction compresses this into micro-role switches within a single session — director → collaborator → student → evaluator — at potentially dozens of transitions per hour. If macro-role switching at ~20 transitions/day produces measurable stress, the frequency compression in AI interaction is a natural candidate for the fatigue users report. See [relational-mode-oscillation](/garden/relational-mode-oscillation/).

--- a/src/content/posts/2026-06-01-relational-switching-costs.md
+++ b/src/content/posts/2026-06-01-relational-switching-costs.md
@@ -1,0 +1,84 @@
+---
+title: "You Don't Have a Relationship with Your LLM. You Have Five."
+published: 2026-06-01
+tags:
+  - 'AI'
+  - 'cognitive psychology'
+  - 'human-AI interaction'
+abbrlink: 'relational-switching-costs'
+lang: ''
+excerpt: >
+  The fatigue from a day of AI pair-programming isn't information overload or decision fatigue. You are unconsciously switching between five relational modes with the AI — director, trainer, partner, student, consumer — dozens of times per session. Each switch costs executive attention, emotional labor compounds the cost, and the AI's lack of emotional reciprocity prevents recovery. Three mechanisms, one conjecture, falsifiable predictions.
+categories:
+  - Professional
+---
+
+This is happening to me often enough to where I need to understand it. It's not just me. I have heard this from my colleagues and friends as well. It is this strange feeling of fatigue when I have spent a large portion of the day chatting with the AI agent to generate code and get work done. I have seen it referred to as "AI fatigue", but that doesn't quite capture the feeling and does even less to explain it.
+
+The standard explanations for it include information overload, decision fatigue (from evaluating AI output), cost of increased productivity, etc. They all capture parts of it and don't seem to add up to the entirety of the experience. Sure, there is some cost to evaluating AI output, but I do that with code reviews from human-authored code too, and it does not drain me out like this. Yeah, I am more productive, but that's AI doing the heavy lifting; so why do I feel tired?
+
+In search of an explanation, I started digging around academic research and published reports to see if this has been figured out. What I found was a bunch of adjacent literature that seems to connect up to something, but no kill shot. This post presents my conjecture based on what I have read, and possible experiments that could disprove my conjecture.
+
+## The five relationships
+
+There have been multiple studies that all point to the same thing. When you are working with an AI agent, you are subconsciously developing a relationship with the AI (albeit an unrequited one) despite consciously recognizing that the AI is "just a tool". You get occasional glimpses of this relationship when you find yourself saying "please" or swearing at the AI in text; you would never do this with your compiler, and yet it is normal with an AI agent.
+
+Your relationship with the AI can take five forms, [oscillating between them unconsciously](/garden/relational-mode-oscillation/) ([Gülay et al. 2025](https://doi.org/10.48550/arXiv.2509.15836)):
+
+1. *Director*: You are giving instructions to the AI agent to perform tasks (such as "refactor this module")
+2. *Trainer*: You are teaching the AI agent how to perform the tasks (e.g., "Use the `git log` command to fetch the historical commits").
+3. *Partner*: Here you are collaboratively working with the AI to accomplish the task (e.g., you come up with a hypothesis for a root cause and ask the AI agent to come up with counter examples to falsify it, and then look for evidence)
+4. *Student*: You are asking the AI to teach you things. (e.g., you ask the agent to summarize a design document, or ask it to explain how, say, Kafka works)
+5. *Consumer*: You are asking and following instructions from the AI. (e.g., you have a root cause of a bug and you ask the AI how you should fix it)
+
+Others have found different ways to categorize this relationship. If you think of ways in which you use AI to obtain knowledge and understanding ([Yang & Ma 2025](https://doi.org/10.48550/arXiv.2508.03673)), you get five different categories: Instrumental Reliance, Contingent Delegation, Co-agency Collaboration, Authority Displacement, Epistemic Abstention. The area of study involving our interactions with AI is still nascent, and so we do not have stable categories yet.
+
+Regardless, we do have different forms of relationships with AI, and what makes this interesting is that we are in all these forms of relationships with the AI *simultaneously*. Within a single session, you switch from one form of relationship to another, and this happens seamlessly and without your conscious acknowledgement. You start a session commanding ("fix this bug"), shift to collaborating ("what if we tried X instead?"), find yourself teaching ("no, the constraint is Y because..."), then deferring ("actually your approach is better"), then passively reviewing output. Five modes. One conversation. You didn't decide to switch. You just did.
+
+The fatigue you feel at the end of the day is an accumulation of these relationship oscillations.
+
+## The switching is not free
+
+We have evidence from the cognitive task switching literature ([Monsell 2003](https://doi.org/10.1016/S1364-6613(03)00028-7); [Rogers & Monsell 1995](https://doi.org/10.1037/0096-3445.124.2.207); [Kiesel et al. 2010](https://doi.org/10.1037/a0019842)) that switching between tasks carries measurable, residual costs. This happens because when we switch tasks, we are really reconfiguring our mental set: new expectations, response mappings, and success criteria. This cost is why multitasking is less productive than spending a focused amount of time on a single task.
+
+The switching cost extends from tasks to relationships as well. Studies show that [social role-switching frequency is a predictor of stress](/garden/role-switching-frequency-predicts-stress/), independent of the total number of roles ([Cornwell 2013](https://doi.org/10.1177/0190272513482133)). It's not that having more roles is stressful — it's that switching between them more often is.
+
+Each of the five relationship modes with AI carries different expectations for what counts as good output, how to phrase your input, what level of explanation to provide, and whether to accept or challenge the response. Each switch is a reconfiguration of mental set, which is the same mechanism Monsell documents for cognitive tasks, applied to social framing. If (and it is an *if*) the mechanisms associated with the relationship switches with AI are the same as the task and role switching in social contexts, then the fatigue from such stress simply follows naturally.
+
+## Emotional labor tax
+
+There is an added cost to interacting with AI. We are not simply talking to the AI, we are performing and acting out a persona. Each relationship mode requires us to take on a different persona. Directing an AI requires one emotional register (authority, concision). Teaching it requires another (patience, pedagogical framing). Collaborating with it requires a third (openness, intellectual generosity). Each switch is not just a cognitive reconfiguration — it's an emotional labor transition. You're changing which emotions you're performing, not just which task you're doing.
+
+The emotional labor literature (e.g. [Hochschild 1983](https://openlibrary.org/works/OL3296551W) and [Brotheridge & Lee 2002](https://doi.org/10.1037/1076-8998.7.1.57)) shows that performing emotions you don't feel (surface acting) depletes cognitive resources. The literature has extensively studied the cost of sustained surface acting toward one audience — customers, patients, students. *What it has not studied is the cost of switching emotional performances rapidly within a single interaction.*
+
+**My conjecture is that these results transfer to our interactions with AI, and so the cost of emotional labor acts as a compounding factor on top of the cost of switching relationship modes itself.** Nobody has studied what happens when you're switching cognitive frames, social roles, AND emotional performances simultaneously, dozens of times per session. In isolation, these literatures point in the same direction, but they measure different things on different timescales: Task switching literature measures costs in milliseconds in controlled tasks; role switching literature measures daily stress; and emotional labor literature measures chronic burnout. The convergence is thematic, not mechanistic. That's what makes this a conjecture worth testing, not a conclusion.
+
+## Instability surcharge
+
+With a human colleague, you settle into a relationship mode relatively quickly, and the changes in the mode are occasional and they evolve. For example, it could start with "he is my tech lead", and in a few months "he is my manager". It typically happens unconsciously. With a tool, you settle into "this is a tool" and the framing never wavers. But our relationship is not that. We just saw that.
+
+[AI agents are categorically ambiguous](/garden/categorical-ambiguity-of-ai/). You say it is a tool; you know it is a tool; you want to use it as a tool. Yet, when you actually start using it, your relationship with it changes, and it changes continually.
+
+Previously, under the ["Computers are Social Actors" (CASA) framework](/garden/casa-framework/) ([Nass & Moon 2000](https://doi.org/10.1111/0022-4537.00153)), the claim was that people apply social rules to computers automatically because the computer's outputs trigger social cues (albeit minimal). But this seems to not apply with AI agents.
+
+One reason could be that the AI is a novel technology that we haven't seen before, and so we are not habituated to it. Recent work shows that [CASA effects may not survive habituation](/garden/casa-habituation/) ([Heyselaar 2023](https://doi.org/10.1038/s41598-023-46527-9), *Scientific Reports*): replicating the CASA experiment with people who grew up with computers around them, the habituation with the technology seemed to have nullified the CASA effect. So perhaps, our next generation will not have any such issue. But I suspect that is not the story. Desktop computers and AI agents are categorically different.
+
+AI agents' social cues are rich but also simultaneously inconsistent. AI can act like a subordinate, assert like a peer, or even explain complex concepts like a teacher, and it all happens in the same conversation. CASA's prediction holds when the computer's social cues are coherent, and here they are not. With contradictory cues, we now have conflicting signals, the ambiguity around the relationship mode with the AI agent never resolves. We are forever in a situationship with the AI.
+
+## Unrequited debt
+
+You might have a relationship with the AI, but AI does not have a relationship with you. Recall from Emotional labor theory that performing social behavior depletes cognitive resources. Interestingly, social reciprocity partially replenishes it between switches. This recovery mechanism is built into the interaction, which is why you are not a dried husk after day-long interactions with your colleagues (assuming you actually like working with them). But an AI agent is a different matter.
+
+Your AI agent returns well-formed output and gives you useful feedback, but it does not provide emotional reciprocity. It does not feel 'thankful' nor does it 'look forward' to interacting with you. Human-agent interaction is genuinely social and effortful ([Banks 2026](https://doi.org/10.1093/jcmc/zmac026), "Ghosting the Machine"), which means that the depletion is real with no recourse for replenishment. It is completely unrequited.
+
+This [absence of reciprocity accelerates the fatigue](/garden/broken-reciprocity-as-fatigue-accelerant/). If you were to treat the AI (say) as a subordinate all day long, then your emotional labor would leave you depleted. But that is not how you treat the AI agent. You are constantly switching modes, and each switch has an additional cost on top of your ongoing cost of this unrequited interaction. Your cognitive resources are depleting with each interaction, faster with each switch, and there is no avenue for replenishment.
+
+## Your situationship explained
+
+Here is my hypothesis. The AI fatigue is not about doing too much or being too productive or making too many decisions. AI's interaction pattern subconsciously draws you into a relationship with it. This relationship is constantly changing and does not have a stable interaction frame. This is compounded by the emotional labor on each switch of the frame, and accelerated by the lack of emotional reciprocity from the AI. There are three factors that compound: the relationship mode switching is the driver, the emotional labor is the multiplier, and the broken reciprocity prevents attenuation of the cost.
+
+Like all good hypotheses, this one is falsifiable. Here are some experiments to shed light on the phenomenon. Take away the AI agent, and replace it with a human, and the fatigue should become significantly attenuated. If you were to coerce the interaction with AI to be in a single relationship mode, the effect should be a lot smaller. Reduce the number of switches, and the fatigue should be less. I am sure you can think of many more.
+
+If I am right, then the issue isn't that the AI isn't more human-like. The culprit is that AI's social cues are inconsistent and without emotional reciprocity. Making AI more human-like without making it relationally consistent should only make the problem worse.
+
+All of this is not to say that we should make AI less capable or use it less. It almost begs for the opposite. Not that we should make AI more human-like; we should make AI more capable of holding a relationship with a human in a fixed or natural register. This problem looks solvable.


### PR DESCRIPTION
One-line fix: if `status:` is empty in PKM frontmatter, fall back to `maturity:` field. Notes created with the `maturity:` convention were all defaulting to seedling.