### PR TITLE
Unify PKM/garden vocabulary: status → maturity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Review PKM items (thoughts, notes, sources) related to the post. Not everything 
 
 The script generates `src/content/garden/` files with frontmatter derived from your PKM. Review and adjust:
 - **Title** — auto-derived from the slug if missing; verify it reads well
-- **Maturity** — auto-derived from PKM status; override if wrong
+- **Maturity** — auto-derived from PKM `maturity` field; override if wrong
 - **Excerpt** — auto-extracted first sentence; tighten if needed
 - **Related notes** — auto-populated from PKM cross-refs; add any missing
 
@@ -59,13 +59,13 @@ Read each new garden note. For every concept mentioned that has its own garden e
 
 ### 5. Set Maturity Levels
 
-Review each note and assign the right maturity:
+Review each note and assign the right maturity (same `maturity` field in both PKM and garden):
 
-| Maturity | When to use | PKM equivalent |
-|----------|-------------|----------------|
-| 🌱 `seedling` | Early idea, might change substantially | `raw` or no status |
-| 🌿 `budding` | Developed argument with room to grow | `developing` or `draft` |
-| 🌳 `evergreen` | Stable definition/framework, unlikely to change | `connected` or `stable` |
+| Maturity | When to use |
+|----------|-------------|
+| 🌱 `seedling` | Early idea, might change substantially |
+| 🌿 `budding` | Developed argument with room to grow |
+| 🌳 `evergreen` | Stable definition/framework, unlikely to change |
 
 Sources default to `evergreen`.
 
@@ -82,15 +82,9 @@ git commit -m "Add post: Your Title + garden notes"
 git push origin post/your-post-slug
 ```
 
-### 7. Update PKM Status
+### 7. Verify PKM Maturity
 
-After publishing, update the PKM thought `status` fields to match the garden maturity:
-
-| Garden maturity | PKM status |
-|----------------|------------|
-| `seedling` | `raw` |
-| `budding` | `developing` |
-| `evergreen` | `connected` |
+After publishing, verify the PKM `maturity` fields match the garden maturity. Since both use the same vocabulary (`seedling`, `budding`, `evergreen`), they should already be in sync from the conversion step.
 
 ---
 

--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -249,6 +249,7 @@ for pkm_file in "${FILES[@]}"; do
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
     pkm_status=$(get_fm "$pkm_file" "status")
+    [ -z "$pkm_status" ] && pkm_status=$(get_fm "$pkm_file" "maturity")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")

--- a/scripts/pkm-to-garden-astro.sh
+++ b/scripts/pkm-to-garden-astro.sh
@@ -112,15 +112,15 @@ kebab_to_title() {
     echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) tolower(substr($i,2))}}1'
 }
 
-# Derive maturity from PKM status and type
+# Derive maturity from PKM maturity field and type
 derive_maturity() {
-    local pkm_type="$1" status="$2"
+    local pkm_type="$1" pkm_maturity="$2"
     # Sources default to evergreen
     if [ "$pkm_type" = "source" ]; then
         echo "evergreen"
         return
     fi
-    case "$status" in
+    case "$pkm_maturity" in
         evergreen|connected|stable) echo "evergreen" ;;
         budding|developing|draft)   echo "budding" ;;
         seedling|raw|"")            echo "seedling" ;;
@@ -248,8 +248,8 @@ for pkm_file in "${FILES[@]}"; do
 
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
-    pkm_status=$(get_fm "$pkm_file" "status")
-    [ -z "$pkm_status" ] && pkm_status=$(get_fm "$pkm_file" "maturity")
+    pkm_maturity=$(get_fm "$pkm_file" "maturity")
+    [ -z "$pkm_maturity" ] && pkm_maturity=$(get_fm "$pkm_file" "status")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")
@@ -282,7 +282,7 @@ for pkm_file in "${FILES[@]}"; do
     fi
 
     # Maturity
-    maturity=$(derive_maturity "$pkm_type" "$pkm_status")
+    maturity=$(derive_maturity "$pkm_type" "$pkm_maturity")
 
     # Tags: parse inline array format [a, b, c]
     tags_line=""

--- a/scripts/pkm-to-garden.sh
+++ b/scripts/pkm-to-garden.sh
@@ -110,15 +110,15 @@ kebab_to_title() {
     echo "$1" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) tolower(substr($i,2))}}1'
 }
 
-# Derive maturity from PKM status and type
+# Derive maturity from PKM maturity field and type
 derive_maturity() {
-    local pkm_type="$1" status="$2"
+    local pkm_type="$1" pkm_maturity="$2"
     # Sources default to evergreen
     if [ "$pkm_type" = "source" ]; then
         echo "evergreen"
         return
     fi
-    case "$status" in
+    case "$pkm_maturity" in
         evergreen|connected|stable) echo "evergreen" ;;
         budding|developing|draft)   echo "budding" ;;
         seedling|raw|"")            echo "seedling" ;;
@@ -246,7 +246,8 @@ for pkm_file in "${FILES[@]}"; do
 
     pkm_id=$(get_fm "$pkm_file" "id")
     pkm_title=$(get_fm "$pkm_file" "title" | sed 's/^"//;s/"$//')
-    pkm_status=$(get_fm "$pkm_file" "status")
+    pkm_maturity=$(get_fm "$pkm_file" "maturity")
+    [ -z "$pkm_maturity" ] && pkm_maturity=$(get_fm "$pkm_file" "status")
     pkm_tags=$(get_fm "$pkm_file" "tags")
     pkm_created=$(get_fm "$pkm_file" "created")
     pkm_date_added=$(get_fm "$pkm_file" "date_added")
@@ -268,7 +269,7 @@ for pkm_file in "${FILES[@]}"; do
     fi
 
     # Maturity
-    maturity=$(derive_maturity "$pkm_type" "$pkm_status")
+    maturity=$(derive_maturity "$pkm_type" "$pkm_maturity")
 
     # Tags: parse inline array format [a, b, c]
     tags_line=""


### PR DESCRIPTION
Replaces PR #146 (which was contaminated with stale RSC post commits).

Two changes:
1. pkm-to-garden scripts: read `maturity` primarily, fall back to `status` for legacy files
2. CONTRIBUTING.md: unified vocabulary (same `maturity` field in both PKM and garden)

Clean branch from main — no stale post files.