### PR TITLE
infra: bump astro-og-canvas to 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/sitemap": "^3.7.2",
     "astro": "^6.1.5",
     "astro-compress": "^2.4.1",
-    "astro-og-canvas": "^0.11.0",
+    "astro-og-canvas": "^0.13.0",
     "canvaskit-wasm": "^0.41.1",
     "feed": "^5.2.0",
     "lite-youtube-embed": "^0.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1(@types/node@25.6.2)(jiti@2.7.0)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.4)
       astro-og-canvas:
-        specifier: ^0.11.0
-        version: 0.11.1(astro@6.3.1(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+        specifier: ^0.13.0
+        version: 0.13.0(astro@6.3.1(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -1173,8 +1173,8 @@ packages:
   astro-compress@2.4.1:
     resolution: {integrity: sha512-bKPNuajD05ecjiZy/8nqTEOWErFttH/j+adWrvXTARcMieCdI5UdBvvhr+8lrpCXFImiYTwUongj2cDywlSW2Q==}
 
-  astro-og-canvas@0.11.1:
-    resolution: {integrity: sha512-6omy7MJeOPwxdYH5+eL3zFIY9MhuDRUMuASuCx/eXNrHGUogq9ZHdx19A428KtWhLVuXVcLt7Klw5fxqASAHmg==}
+  astro-og-canvas@0.13.0:
+    resolution: {integrity: sha512-jcIDhE9OGIbd7LstZQ4CyzOpbbEKAlxJqEgdkVu6r26m7yJKlQjKysszfDxlox717cnCLPXKivyFjsufcq8sYA==}
     peerDependencies:
       astro: ^5.0.0 || ^6.0.0-alpha
 
@@ -3811,7 +3811,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro-og-canvas@0.11.1(astro@6.3.1(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+  astro-og-canvas@0.13.0(astro@6.3.1(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       astro: 6.3.1(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.3)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       canvaskit-wasm: 0.41.1


### PR DESCRIPTION
Fixes OG prerender failure (countFamilies null) seen on Vercel:

- TypeError: Cannot read properties of null (reading 'countFamilies') at #getOrCreateManager during /og/2007-06-24-tryst-with-kudremukh.png build
- Root cause: astro-og-canvas 0.11.1 + canvaskit-wasm 0.41.1 wasm init race under Astro 6 / Node 22, triggered on old posts but affects all OG builds

This PR only bumps the dependency correctly:
- package.json ^0.11.0 → ^0.13.0
- pnpm-lock.yaml updated with new integrity

Verified: pnpm-lock specifier matches package.json (previous failure was lockfile mismatch).

No change to OG generation logic itself — stays static prerender, not @vercel/og (which is Vercel-only).

Test plan: let Vercel preview build; OG images should generate without countFamilies error.